### PR TITLE
Translate account templates to English with i18n tags

### DIFF
--- a/core/templates/accounts/login.html
+++ b/core/templates/accounts/login.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load i18n %}
 
 
 {% block content %}
@@ -6,8 +7,8 @@
     <div class="flex-grow-1 mx-auto" style="max-width: 28rem;">
         <!-- Heading -->
         <div class="text-center mb-5 mb-md-7">
-            <h1 class="h2">فرم ورود</h1>
-            <p>برای مدیریت حساب خود وارد شوید.</p>
+            <h1 class="h2">{% trans "Login form" %}</h1>
+            <p>{% trans "Sign in to manage your account." %}</p>
         </div>
         <!-- End Heading -->
 
@@ -16,23 +17,23 @@
             {% csrf_token %}
             <!-- Form -->
             <div class="mb-4">
-                <label class="form-label" for="signupSimpleLoginEmail">ایمیل شما</label>
+                <label class="form-label" for="signupSimpleLoginEmail">{% trans "Email address" %}</label>
                 <input type="email" class="form-control form-control-lg text-center" name="username"
-                    id="signupSimpleLoginEmail" placeholder="email@site.com" aria-label="email@site.com" required>
-                <span class="invalid-feedback">لطفا یک آدرس ایمیل معتبر وارد کنید.</span>
+                    id="signupSimpleLoginEmail" placeholder="{% trans 'email@site.com' %}" aria-label="{% trans 'email@site.com' %}" required>
+                <span class="invalid-feedback">{% trans "Please enter a valid email address." %}</span>
             </div>
             <!-- End Form -->
 
             <!-- Form -->
             <div class="mb-4">
                 <div class="d-flex justify-content-between align-items-center">
-                    <label class="form-label" for="signupSimpleLoginPassword">کلمه عبور</label>
+                    <label class="form-label" for="signupSimpleLoginPassword">{% trans "Password" %}</label>
 
                 </div>
 
                 <div class="input-group input-group-merge" data-hs-validation-validate-class>
                     <input type="password" class="js-toggle-password form-control form-control-lg text-center" name="password"
-                      id="signupSimpleLoginPassword" placeholder="8+ characters required" aria-label="8+ characters required"
+                      id="signupSimpleLoginPassword" placeholder="{% trans '8+ characters required' %}" aria-label="{% trans '8+ characters required' %}"
                       required minlength="8" data-hs-toggle-password-options='{
                       "target": "#changePassTarget",
                       "defaultClass": "bi-eye-slash",
@@ -44,17 +45,17 @@
                     </a>
                   </div>
 
-                <span class="invalid-feedback">لطفا یک گذر واژه معتبر وارد کنید.</span>
+                <span class="invalid-feedback">{% trans "Please enter a valid password." %}</span>
             </div>
             <!-- End Form -->
 
             <div class="d-grid mb-3">
-                <a class="form-label-link" href="{% url 'password_reset' %}">رمز عبور را فراموش کرده اید؟</a>
-                <button type="submit" class="btn btn-primary btn-lg">ورود</button>
+                <a class="form-label-link" href="{% url 'password_reset' %}">{% trans "Forgot your password?" %}</a>
+                <button type="submit" class="btn btn-primary btn-lg">{% trans "Sign in" %}</button>
             </div>
 
             <div class="text-center">
-                <p>حساب کاربری ندارید؟ <a class="link" href="{% url 'sign-up' %}">اینجا ثبت نام کنید</a></p>
+                <p>{% trans "Don't have an account?" %} <a class="link" href="{% url 'sign-up' %}">{% trans "Register here" %}</a></p>
             </div>
             {{form.captcha}}
         </form>

--- a/core/templates/accounts/reset_password/reset_password.html
+++ b/core/templates/accounts/reset_password/reset_password.html
@@ -1,18 +1,19 @@
 {% extends "base.html" %}
+{% load i18n %}
 {% load static %}
 
 {% block content %}
 <div class="container d-flex justify-content-center align-items-center vh-100">
     <div class="card p-4 shadow" style="max-width: 400px; width: 100%;">
-        <h3 class="card-title text-center mb-3">بازنشانی ایمیل</h3>
-        <p class="text-muted text-center">ایمیل خود را وارد کنید تا ایمیل حاوی لینک ارسال گردد</p>
+        <h3 class="card-title text-center mb-3">{% trans "Reset email" %}</h3>
+        <p class="text-muted text-center">{% trans "Enter your email address and we'll send you a reset link." %}</p>
         <form method="post">
             {% csrf_token %}
             <div class="mb-3">
-                <label for="email" class="form-label">ایمیل</label>
-                <input type="email" class="form-control" id="email" name="email" placeholder="ایمیل خود را وارد کنید" required>
+                <label for="email" class="form-label">{% trans "Email" %}</label>
+                <input type="email" class="form-control" id="email" name="email" placeholder="{% trans 'Enter your email' %}" required>
             </div>
-            <button type="submit" class="btn btn-primary w-100">ارسال لینک</button>
+            <button type="submit" class="btn btn-primary w-100">{% trans "Send link" %}</button>
         </form>
     </div>
 </div>

--- a/core/templates/accounts/reset_password/reset_password_complete.html
+++ b/core/templates/accounts/reset_password/reset_password_complete.html
@@ -1,12 +1,13 @@
 {% extends "base.html" %}
+{% load i18n %}
 {% load static %}
 
 {% block content %}
 <div class="container d-flex justify-content-center align-items-center vh-100" style="display: none;" id="reset-complete">
     <div class="card p-4 shadow" style="max-width: 400px; width: 100%;">
-        <h3 class="card-title text-center mb-3">بازنشانی رمز عبور کامل شد</h3>
-        <p class="text-muted text-center">رمز عبور شما با موفقیت تنظیم شد. اکنون می‌توانید وارد حساب کاربری خود شوید.</p>
-        <a href="{% url 'login' %}" class="btn btn-primary w-100">ورود</a>
+        <h3 class="card-title text-center mb-3">{% trans "Password reset complete" %}</h3>
+        <p class="text-muted text-center">{% trans "Your password has been set successfully. You can now sign in to your account." %}</p>
+        <a href="{% url 'login' %}" class="btn btn-primary w-100">{% trans "Sign in" %}</a>
     </div>
 </div>
 {% endblock content %}

--- a/core/templates/accounts/reset_password/reset_password_done.html
+++ b/core/templates/accounts/reset_password/reset_password_done.html
@@ -1,12 +1,13 @@
 {% extends "base.html" %}
+{% load i18n %}
 {% load static %}
 
 {% block content %}
 <div class="container d-flex justify-content-center align-items-center vh-100" style="display: none;" id="success-message">
     <div class="card p-4 shadow" style="max-width: 400px; width: 100%;">
-        <h3 class="card-title text-center mb-3">ایمیل ارسال شد</h3>
-        <p class="text-muted text-center">لینک بازنشانی رمز عبور به ایمیل شما ارسال شد. لطفاً صندوق ورودی خود را بررسی کنید.</p>
-        <a href="/" class="btn btn-primary w-100">بازگشت به صفحه اصلی</a>
+        <h3 class="card-title text-center mb-3">{% trans "Email sent" %}</h3>
+        <p class="text-muted text-center">{% trans "A password reset link has been sent to your email. Please check your inbox." %}</p>
+        <a href="/" class="btn btn-primary w-100">{% trans "Return to homepage" %}</a>
     </div>
 </div>
 {% endblock content %}

--- a/core/templates/accounts/reset_password/reset_password_form.html
+++ b/core/templates/accounts/reset_password/reset_password_form.html
@@ -1,24 +1,25 @@
 {% extends "base.html" %}
+{% load i18n %}
 {% load static %}
 
 {% block content %}
 <div class="container d-flex justify-content-center align-items-center vh-100" style="display: none;" id="reset-password-form">
     <div class="card p-4 shadow" style="max-width: 400px; width: 100%;">
-        <h3 class="card-title text-center mb-3">تنظیم گذرواژه جدید</h3>
-        <p class="text-muted text-center">گذرواژه جدید خود را وارد کنید</p>
+        <h3 class="card-title text-center mb-3">{% trans "Set a new password" %}</h3>
+        <p class="text-muted text-center">{% trans "Enter your new password below." %}</p>
         <form method="post">
             {% csrf_token %}
             <div class="mb-3">
-                <label for="password" class="form-label">گذرواژه</label>
+                <label for="password" class="form-label">{% trans "Password" %}</label>
                 {{form.new_password1}}
             </div>
             <div class="mb-3">
-                <label for="confirm-password" class="form-label">تایید گذرواژه</label>
+                <label for="confirm-password" class="form-label">{% trans "Confirm password" %}</label>
                 {{form.new_password2}}
             </div>
-            <button type="submit" class="btn btn-primary w-100">تغییر گذرواژه</button>
+            <button type="submit" class="btn btn-primary w-100">{% trans "Change password" %}</button>
         </form>
-        <p class="text-muted mt-3">Make sure your new password is strong and memorable. Avoid using common words or personal information.</p>
+        <p class="text-muted mt-3">{% trans "Make sure your new password is strong and memorable. Avoid using common words or personal information." %}</p>
     </div>
 </div>
 {% endblock content %}

--- a/core/templates/accounts/signup.html
+++ b/core/templates/accounts/signup.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load i18n %}
 
 
 {% block content %}
@@ -6,8 +7,8 @@
     <div class="flex-grow-1 mx-auto" style="max-width: 28rem;">
       <!-- Heading -->
       <div class="text-center mb-5 mb-md-7">
-        <h1 class="h2">فرم ثبت نام</h1>
-        <p>برای ثبت نام کافیست فرم زیر را پر نمایید</p>
+        <h1 class="h2">{% trans "Sign-up form" %}</h1>
+        <p>{% trans "Complete the form below to create your account." %}</p>
       </div>
       <!-- End Heading -->
 
@@ -16,20 +17,20 @@
         {% csrf_token %}
         <!-- Form -->
         <div class="mb-3">
-          <label class="form-label" for="signupSimpleSignupEmail">ایمیل شما</label>
+          <label class="form-label" for="signupSimpleSignupEmail">{% trans "Email address" %}</label>
           <input type="email" class="form-control form-control-lg text-center" name="email" id="signupSimpleSignupEmail"
-            placeholder="email@site.com" aria-label="email@site.com" required>
-          <span class="invalid-feedback">لطفا یک آدرس ایمیل معتبر وارد کنید.</span>
+            placeholder="{% trans 'email@site.com' %}" aria-label="{% trans 'email@site.com' %}" required>
+          <span class="invalid-feedback">{% trans "Please enter a valid email address." %}</span>
         </div>
         <!-- End Form -->
 
         <!-- Form -->
         <div class="mb-3">
-          <label class="form-label" for="signupSimpleSignupPassword">رمز عبور</label>
+          <label class="form-label" for="signupSimpleSignupPassword">{% trans "Password" %}</label>
 
           <div class="input-group input-group-merge" data-hs-validation-validate-class>
             <input type="password" class="js-toggle-password form-control form-control-lg text-center" name="password1"
-              id="signupSimpleSignupPassword" placeholder="8+ characters required" aria-label="8+ characters required"
+              id="signupSimpleSignupPassword" placeholder="{% trans '8+ characters required' %}" aria-label="{% trans '8+ characters required' %}"
               required data-hs-toggle-password-options='{
                        "target": [".js-toggle-password-target-1", ".js-toggle-password-target-2"],
                        "defaultClass": "bi-eye-slash",
@@ -41,18 +42,18 @@
             </a>
           </div>
 
-          <span class="invalid-feedback">رمز عبور شما نامعتبر است. لطفا دوباره تلاش کنید.</span>
+          <span class="invalid-feedback">{% trans "Your password is invalid. Please try again." %}</span>
         </div>
         <!-- End Form -->
 
         <!-- Form -->
         <div class="mb-3">
-          <label class="form-label" for="signupSimpleSignupConfirmPassword">رمز عبور را تایید کنید</label>
+          <label class="form-label" for="signupSimpleSignupConfirmPassword">{% trans "Confirm password" %}</label>
 
           <div class="input-group input-group-merge" data-hs-validation-validate-class>
             <input type="password" class="js-toggle-password form-control form-control-lg text-center" name="password2"
-              id="signupSimpleSignupConfirmPassword" placeholder="8+ characters required"
-              aria-label="8+ characters required" required
+              id="signupSimpleSignupConfirmPassword" placeholder="{% trans '8+ characters required' %}"
+              aria-label="{% trans '8+ characters required' %}" required
               data-hs-validation-equal-field="#signupSimpleSignupPassword" data-hs-toggle-password-options='{
                      "target": [".js-toggle-password-target-1", ".js-toggle-password-target-2"],
                      "defaultClass": "bi-eye-slash",
@@ -64,7 +65,7 @@
             </a>
           </div>
 
-          <span class="invalid-feedback">رمز عبور با رمز عبور تأیید مطابقت ندارد.</span>
+          <span class="invalid-feedback">{% trans "The password and confirmation do not match." %}</span>
         </div>
         <!-- End Form -->
 
@@ -72,18 +73,21 @@
         <div class="form-check mb-3">
           <input type="checkbox" class="form-check-input" id="signupHeroFormPrivacyCheck"
             name="signupFormPrivacyCheck" required>
-          <label class="form-check-label small" for="signupHeroFormPrivacyCheck"><a href="#">سیاست حفظ حریم خصوصی</a> با ارسال این فرم من آن را خوانده و
-            تایید کرده ام </label>
-          <span class="invalid-feedback">لطفاً سیاست حفظ حریم خصوصی ما را بپذیرید.</span>
+          <label class="form-check-label small" for="signupHeroFormPrivacyCheck">
+            {% blocktrans trimmed with privacy_link_start='<a href="#">'|safe privacy_link_end='</a>' %}
+            By submitting this form, I confirm that I have read and agreed to the {{ privacy_link_start }}privacy policy{{ privacy_link_end }}.
+            {% endblocktrans %}
+          </label>
+          <span class="invalid-feedback">{% trans "Please accept our privacy policy." %}</span>
         </div>
         <!-- End Check -->
 
         <div class="d-grid mb-3">
-          <button type="submit" class="btn btn-primary btn-lg">ثبت نام</button>
+          <button type="submit" class="btn btn-primary btn-lg">{% trans "Sign up" %}</button>
         </div>
 
         <div class="text-center">
-          <p>از قبل حساب کاربری دارید؟<a class="link" href="{% url 'login' %}">از اینجا وارد شوید</a></p>
+          <p>{% trans "Already have an account?" %} <a class="link" href="{% url 'login' %}">{% trans "Sign in here" %}</a></p>
         </div>
         {{form.captcha}}
       </form>


### PR DESCRIPTION
## Summary
- replace Arabic text in the account authentication templates with English copy
- wrap user-facing strings in Django translation tags to enable English and French locales

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e435088ca08320b373bed9d2ed1ba2