### PR TITLE
Add Django translations to cart and dashboard templates

### DIFF
--- a/core/templates/cart/cart.html
+++ b/core/templates/cart/cart.html
@@ -1,4 +1,8 @@
-{% extends "base.html" %} {% load static %} {% load humanize %} {% block content %}
+{% extends "base.html" %}
+{% load static %}
+{% load humanize %}
+{% load i18n %}
+{% block content %}
 <!-- ========== MAIN CONTENT ========== -->
   <div class="container content-space-1 content-space-lg-2">
     <div class="row">
@@ -7,8 +11,14 @@
         <div
         class="d-flex justify-content-between align-items-end border-bottom pb-3 mb-7"
         >
-        <h1 class="h3 mb-0">سبد خرید</h1>
-        <span>{{total_quantity}} عدد</span>
+        <h1 class="h3 mb-0">{% trans "Shopping Cart" %}</h1>
+        <span>
+          {% blocktrans count item_count=total_quantity %}
+            {{ item_count }} item
+          {% plural %}
+            {{ item_count }} items
+          {% endblocktrans %}
+        </span>
       </div>
       <!-- End Heading -->
       <!-- Form -->
@@ -34,12 +44,12 @@
                     </h5>                      
                       <div class="d-grid gap-1">
                         <div class="text-body">
-                          <span class="small">دسته بندی:</span>
+                          <span class="small">{% trans "Category:" %}</span>
                           <span class="fw-semibold small">
                           {% for cat in prod.prod_obj.category.all %}
                           {{cat}}
                           {% if not forloop.last %}
-                            ،
+                            ,
                           {% endif %}
                           {% endfor %}</span>
                         </div>
@@ -67,7 +77,7 @@
                         <div class="col-auto ">
                           <div class="d-grid gap-2 d-flex justify-content-between">
                               <button class=" btn btn-sm btn-icon text-danger border-0 mx-1" onclick="delprod(`{{ prod.product_id }}`)">
-                                  <i class="bi-trash ms-1"></i> حذف
+                              <i class="bi-trash ms-1"></i> {% trans "Remove" %}
                               </button>
                           </div>
                       </div>
@@ -84,7 +94,7 @@
                     <span class="text-body ms-1"><del>{{prod.prod_obj.price|intcomma}}</del></span>
                     {% endif %}
                     <span class="h5 d-block mb-1">{{prod.prod_obj.offer|intcomma}}</span>
-                    <p>تومان</p>
+                    <p>{% trans "Toman" %}</p>
                     </div>
                     <!-- End Col -->
                   </div>
@@ -99,7 +109,7 @@
           
           <div class="d-sm-flex justify-content-end">
             <a class="link" href="{% url 'shop:list_grid' %}">
-              به خرید ادامه دهید <i class="bi-chevron-left small ms-1"></i>
+              {% trans "Continue shopping" %} <i class="bi-chevron-left small ms-1"></i>
             </a>
           </div>
         </form>
@@ -113,30 +123,30 @@
           <div class="card card-sm shadow-sm mb-4">
             <div class="card-body">
               <div class="border-bottom pb-4 mb-4">
-                <h3 class="card-header-title">خلاصه هزینه</h3>
+                <h3 class="card-header-title">{% trans "Order Summary" %}</h3>
               </div>
               <form>
                 <div class="d-grid gap-3 mb-4">
                   <dl class="row">
-                    <dt class="col-sm-6">مالیات</dt>
+                    <dt class="col-sm-6">{% trans "Tax" %}</dt>
                     <dd class="col-sm-12 text-sm-end mb-0">
-                      به همراه 9% در هنگام پرداخت
+                      {% trans "Additional 9% at checkout" %}
                     </dd>
                   </dl>
                   <!-- End Row -->
                   
                   <dl class="row">
-                    <dt class="col-sm-6">جمع</dt>
-                    <dd class="col-sm-12 text-sm-end mb-0">{{total_price|intcomma}} تومان</dd>
+                    <dt class="col-sm-6">{% trans "Subtotal" %}</dt>
+                    <dd class="col-sm-12 text-sm-end mb-0">{{total_price|intcomma}} {% trans "Toman" %}</dd>
                   </dl>
                   <!-- End Row -->
                 </div>
                 
                 <div class="d-grid" style="margin-bottom: 10px;">
-                  <a class="btn btn-primary btn-lg" href="{% url 'order:checkout' %}">ثبت سفارش</a>
+                  <a class="btn btn-primary btn-lg" href="{% url 'order:checkout' %}">{% trans "Place Order" %}</a>
                 </div>
                 <div class="d-grid">
-                  <button class="btn btn-danger btn-lg" onclick="clearProducts()">خالی کردن سبد خرید</button>
+                  <button class="btn btn-danger btn-lg" onclick="clearProducts()">{% trans "Empty Cart" %}</button>
                 </div>
                 
               </form>
@@ -172,8 +182,8 @@
               </div>
             </div>
             <div class="flex-grow-1 ms-2">
-              <span class="small me-1">نیاز به پشتیبانی دارید؟</span>
-              <a class="link small" href="{% url 'website:contact' %}">ارسال تیکت</a>
+              <span class="small me-1">{% trans "Need support?" %}</span>
+              <a class="link small" href="{% url 'website:contact' %}">{% trans "Submit a ticket" %}</a>
             </div>
           </div>
           <!-- End Media -->

--- a/core/templates/cart/empty-cart.html
+++ b/core/templates/cart/empty-cart.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
   
@@ -10,11 +11,11 @@
       </div>
 
       <div class="mb-5">
-        <h1 class="h2">سبد خرید شما در حال حاضر خالی است</h1>
-        <p>قبل از شروع تسویه حساب، باید محصولاتی را به سبد خرید خود اضافه کنید. در صفحه "فروشگاه" ما محصولات جالب زیادی پیدا خواهید کرد.</p>
+        <h1 class="h2">{% trans "Your shopping cart is currently empty" %}</h1>
+        <p>{% trans "Before proceeding to checkout, you need to add some products to your cart. You will find lots of interesting products on our \"Shop\" page." %}</p>
       </div>
 
-      <a class="btn btn-primary btn-transition rounded-pill px-6" href="{% url 'shop:list_grid' %}">شروع به خرید کنید</a>
+      <a class="btn btn-primary btn-transition rounded-pill px-6" href="{% url 'shop:list_grid' %}">{% trans "Start shopping" %}</a>
     </div>
   </div>
 

--- a/core/templates/dashboard/admin/base.html
+++ b/core/templates/dashboard/admin/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load i18n %}
 <!DOCTYPE html>
 <html lang="fa" dir="rtl">
 
@@ -63,21 +64,21 @@
                     <ul class="navbar-nav">
                         <li class="nav-item">
                             <a class="nav-link  {% if request.resolver_match.view_name  == 'website:home' %} active {% endif %}"
-                                href="{% url 'website:home' %}">صفحه اصلی</a>
+                                href="{% url 'website:home' %}">{% trans "Home" %}</a>
                         </li>
 
 
                         <li class="nav-item">
                             <a class="nav-link {% if request.resolver_match.view_name  == 'shop:product-grid' %} active {% endif %}"
-                                href="{% url 'shop:list_grid' %}">لیست محصولات</a>
+                                href="{% url 'shop:list_grid' %}">{% trans "Product List" %}</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link {% if request.resolver_match.view_name  == 'website:about' %} active {% endif %}"
-                                href="{% url 'website:about' %}">درباره ما</a>
+                                href="{% url 'website:about' %}">{% trans "About Us" %}</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link {% if request.resolver_match.view_name  == 'website:contact' %} active {% endif %}"
-                                href="{% url 'website:contact' %}">ارتباط با ما</a>
+                                href="{% url 'website:contact' %}">{% trans "Contact Us" %}</a>
                         </li>
 
 
@@ -115,12 +116,12 @@
                             </button>
 
                             <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-                                <a class="dropdown-item" href="{% url 'dashboard:check' %}">پروفایل</a>
-                                <a class="dropdown-item" href="{% url 'logout' %}">خروج</a>
+                                <a class="dropdown-item" href="{% url 'dashboard:check' %}">{% trans "Profile" %}</a>
+                                <a class="dropdown-item" href="{% url 'logout' %}">{% trans "Log out" %}</a>
                             </div>
 
                             {% else %}
-                            <a class="btn btn-primary btn-transition" href="{% url 'login' %}">ورود</a>
+                            <a class="btn btn-primary btn-transition" href="{% url 'login' %}">{% trans "Log in" %}</a>
                             {% endif %}
                         </li>
                     </ul>
@@ -142,7 +143,7 @@
                 <div class="row align-items-center">
                     <div class="col">
                         <div class="d-none d-lg-block">
-                            <h1 class="h2 text-white">داشبورد</h1>
+                            <h1 class="h2 text-white">{% trans "Dashboard" %}</h1>
                         </div>
 
                         <!-- Breadcrumb -->
@@ -155,7 +156,7 @@
 
                     <div class="col-auto">
                         <div class="d-none d-lg-block">
-                            <a class="btn btn-soft-light btn-sm" href="{% url 'logout' %}">خروج</a>
+                            <a class="btn btn-soft-light btn-sm" href="{% url 'logout' %}">{% trans "Log out" %}</a>
                         </div>
                         <!-- Responsive Toggle Button -->
                         <button class="navbar-toggler d-lg-none" type="button" data-bs-toggle="collapse"
@@ -214,41 +215,40 @@
                 </div>
 
                 <div class="col-6 col-md-4 col-lg-3 ms-lg-auto mb-5 mb-lg-0">
-                    <h5>حساب</h5>
+                    <h5>Account</h5>
 
                     <!-- List -->
                     <ul class="list-unstyled list-py-1">
-                        <li><a class="link-sm text-secondary" href="#">سفارش دادن</a></li>
-                        <li><a class="link-sm text-secondary" href="#">گزینه های حمل و نقل</a></li>
-                        <li><a class="link-sm text-secondary" href="#">پیگیری یک بسته</a></li>
-                        <li><a class="link-sm text-secondary" href="#">در دسترس بودن کشور</a></li>
+                        <li><a class="link-sm text-secondary" href="#">Place an order</a></li>
+                        <li><a class="link-sm text-secondary" href="#">Shipping options</a></li>
+                        <li><a class="link-sm text-secondary" href="#">Track a package</a></li>
+                        <li><a class="link-sm text-secondary" href="#">Country availability</a></li>
                     </ul>
                     <!-- End List -->
                 </div>
                 <!-- End Col -->
 
                 <div class="col-6 col-md-4 col-lg-3 mb-5 mb-lg-0">
-                    <h5>شرکت</h5>
+                    <h5>Company</h5>
 
                     <!-- List -->
                     <ul class="list-unstyled list-py-1">
-                        <li><a class="link-sm text-secondary" href="#">تامین مالی</a></li>
-                        <li><a class="link-sm text-secondary" href="#">بازیافت</a></li>
-                        <li><a class="link-sm text-secondary" href="#">سیاست بازگشت</a></li>
+                        <li><a class="link-sm text-secondary" href="#">Financing</a></li>
+                        <li><a class="link-sm text-secondary" href="#">Recycling</a></li>
+                        <li><a class="link-sm text-secondary" href="#">Return policy</a></li>
                     </ul>
                     <!-- End List -->
                 </div>
                 <!-- End Col -->
 
                 <div class="col-md-4 col-lg-2 mb-5 mb-lg-0">
-                    <h5 class="mb-3">منابع</h5>
+                    <h5 class="mb-3">Resources</h5>
 
                     <!-- List -->
                     <ul class="list-unstyled list-py-1">
                         <li><a class="link-sm link-secondary" href="#"><i class="bi-question-circle-fill me-1"></i>
-                                کمک</a></li>
-                        <li><a class="link-sm link-secondary" href="#"><i class="bi-person-circle me-1"></i> حساب
-                                شما</a></li>
+                                Help</a></li>
+                        <li><a class="link-sm link-secondary" href="#"><i class="bi-person-circle me-1"></i> Your account</a></li>
                     </ul>
                     <!-- End List -->
 
@@ -260,7 +260,7 @@
                                 <img class="avatar avatar-xss avatar-circle ms-2"
                                     src="{% static 'vendor/flag-icon-css/flags/1x1/us.svg' %}" alt="Image description"
                                     width="16" />
-                                <span>انگلیسی (US)</span>
+                                <span>English (US)</span>
                             </span>
                         </button>
 
@@ -269,25 +269,25 @@
                                 <img class="avatar avatar-xss avatar-circle ms-2"
                                     src="{% static 'vendor/flag-icon-css/flags/1x1/us.svg' %}" alt="Image description"
                                     width="16" />
-                                <span>انگلیسی</span>
+                                <span>English</span>
                             </a>
                             <a class="dropdown-item d-flex align-items-center" href="#">
                                 <img class="avatar avatar-xss avatar-circle ms-2"
                                     src="{% static 'vendor/flag-icon-css/flags/1x1/de.svg' %}" alt="Image description"
                                     width="16" />
-                                <span>آلمانی</span>
+                                <span>German</span>
                             </a>
                             <a class="dropdown-item d-flex align-items-center" href="#">
                                 <img class="avatar avatar-xss avatar-circle ms-2"
                                     src="{% static 'vendor/flag-icon-css/flags/1x1/es.svg' %}" alt="Image description"
                                     width="16" />
-                                <span>اسپانیایی</span>
+                                <span>Spanish</span>
                             </a>
                             <a class="dropdown-item d-flex align-items-center" href="#">
                                 <img class="avatar avatar-xss avatar-circle ms-2"
                                     src="{% static 'vendor/flag-icon-css/flags/1x1/cn.svg' %}" alt="Image description"
                                     width="16" />
-                                <span>چینی</span>
+                                <span>Chinese</span>
                             </a>
                         </div>
                     </div>
@@ -334,13 +334,13 @@
                     <!-- List -->
                     <ul class="list-inline list-separator">
                         <li class="list-inline-item">
-                            <a class="link-sm link-secondary" href="/page-privacy.html">حریم خصوصی و خط مشی</a>
+                            <a class="link-sm link-secondary" href="/page-privacy.html">Privacy Policy</a>
                         </li>
                         <li class="list-inline-item">
-                            <a class="link-sm link-secondary" href="/page-terms.html">مقررات و شرایط</a>
+                            <a class="link-sm link-secondary" href="/page-terms.html">Terms & Conditions</a>
                         </li>
                         <li class="list-inline-item">
-                            <a class="link-sm link-secondary" href="/#">مشاغل</a>
+                            <a class="link-sm link-secondary" href="/#">Careers</a>
                         </li>
                     </ul>
                     <!-- End List -->
@@ -387,10 +387,10 @@
                             <!-- Input Card -->
                             <div class="input-card">
                                 <div class="input-card-form">
-                                    <input type="text" class="form-control form-control-lg" placeholder="جستجو محصولات"
-                                        name="q" aria-label="جستجو محصولات">
+                                    <input type="text" class="form-control form-control-lg" placeholder="Search products"
+                                        name="q" aria-label="Search products">
                                 </div>
-                                <button type="submit" class="btn btn-primary btn-lg">جستجو کردن</button>
+                                <button type="submit" class="btn btn-primary btn-lg">Search</button>
                             </div>
                             <!-- End Input Card -->
                         </form>

--- a/core/templates/dashboard/admin/coupons/coupon-create.html
+++ b/core/templates/dashboard/admin/coupons/coupon-create.html
@@ -1,11 +1,12 @@
 {% extends "dashboard/admin/base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
 <div class="card">
     <!-- Header -->
     <div class="card-header border-bottom">
-      <h5 class="card-header-title">ساخت کد تخفیف</h5>
+      <h5 class="card-header-title">{% trans "Create discount code" %}</h5>
     </div>
     <!-- End Header -->
 
@@ -17,7 +18,7 @@
 
             <!-- Form -->
             <div class="row mb-4">
-                <label for="firstNameLabel" class="col-sm-3 col-form-label form-label">مقادیر تخفیف</label>
+                <label for="firstNameLabel" class="col-sm-3 col-form-label form-label">{% trans "Discount values" %}</label>
 
                 <div class="col-sm-9">
                   <div class="input-group">
@@ -29,7 +30,7 @@
               <!-- End Form -->
 
               <!-- Form -->
-                <label for="phoneLabel" class="col-sm-3 col-form-label form-label">کد تخفیف</label>
+                <label for="phoneLabel" class="col-sm-3 col-form-label form-label">{% trans "Discount code" %}</label>
 
                 <div class="col-sm-9">
                   <div class="input-group ">
@@ -43,8 +44,8 @@
           <!-- End Form -->
 
           <div class=" d-flex pt-5 justify-content-end">
-            <a class="btn btn-secondary ms-3" href="{% url 'dashboard:admin:coupon-list' %}">بازگشت</a>
-            <button type="submit" class="btn btn-primary ms-3">ثبت کد</button>
+            <a class="btn btn-secondary ms-3" href="{% url 'dashboard:admin:coupon-list' %}">{% trans "Back" %}</a>
+            <button type="submit" class="btn btn-primary ms-3">{% trans "Submit code" %}</button>
           </div>
         </div>
     </form>

--- a/core/templates/dashboard/admin/coupons/coupon-list.html
+++ b/core/templates/dashboard/admin/coupons/coupon-list.html
@@ -1,5 +1,6 @@
 {% extends "dashboard/admin/base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
     <!-- Card -->
@@ -7,8 +8,8 @@
         <!-- Header -->
         <div class="card-header border-bottom">
           <div class="d-flex justify-content-between align-items-center">
-            <h5 class="">لیست تخفیف ها</h5>
-            <a class="btn btn-primary" href="{% url 'dashboard:admin:coupon-create' %}">اضافه کردن</a>
+            <h5 class="">{% trans "Discount list" %}</h5>
+            <a class="btn btn-primary" href="{% url 'dashboard:admin:coupon-create' %}">{% trans "Add" %}</a>
           </div>
         </div>
         <!-- End Header -->
@@ -20,21 +21,21 @@
 
               <!-- Input Card -->
               <div class="col-md-5 py-1">
-                <input type="text" class="form-control" placeholder="جستجوی" aria-label="جستجوی ایمیل" name="q" id="search-query-filter">
+                <input type="text" class="form-control" placeholder="{% trans 'Search' %}" aria-label="{% trans 'Search email' %}" name="q" id="search-query-filter">
 
               </div>
               <!-- End Input Card -->
               <div class="col-md-3 py-1">
                 <select class="form-select" name="order_by" id="order-by-filter">
-                  <option value="-created_date">جدیدترین</option>
-                  <option value="created_date">قدیمی ترین</option>
+                  <option value="-created_date">{% trans "Newest" %}</option>
+                  <option value="created_date">{% trans "Oldest" %}</option>
                 </select>
               </div>
               <div class="col-md-3 py-1">
                 <select class="form-select" name="category_id" id="category-id-filter">
-                    <option value="" selected>انتخاب دسته بندی</option>
-                    <option value="1">فعال</option>
-                    <option value="2">غیر فعال</option>
+                    <option value="" selected>{% trans "Select category" %}</option>
+                    <option value="1">{% trans "Active" %}</option>
+                    <option value="2">{% trans "Inactive" %}</option>
                 </select>
               </div>
               <div class="col-md-1 py-1">
@@ -51,11 +52,11 @@
                 <thead class="thead-light">
                   <tr>
                     <th scope="col">#</th>
-                    <th scope="col">کد تخفیف</th>
-                    <th scope="col">درصد تخفیف</th>
-                    <th scope="col">محدودیت استفاده</th>
-                    <th scope="col">استفاده شده</th>
-                    <th scope="col">وضعیت</th>
+                    <th scope="col">{% trans "Discount code" %}</th>
+                    <th scope="col">{% trans "Discount percentage" %}</th>
+                    <th scope="col">{% trans "Usage limit" %}</th>
+                    <th scope="col">{% trans "Used" %}</th>
+                    <th scope="col">{% trans "Status" %}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -64,9 +65,9 @@
                     <th scope="row">{{forloop.counter}}</th>
                     <td>{{coupon.code}}</td>
                     <td>{{coupon.discount_percent}}%</td>
-                    <td>{{coupon.max_limit_usage}} نفر</td>
-                    <td>{{coupon.used_by.count}} نفر</td>
-                    <td>{% if coupon.max_limit_usage != coupon.used_by.count %}<span class="badge bg-success">فعال</span>{% else %}<span class="badge bg-danger">غیر فعال</span>{% endif %}</td>
+                    <td>{% blocktrans with limit=coupon.max_limit_usage %}{{ limit }} users{% endblocktrans %}</td>
+                    <td>{% blocktrans with used=coupon.used_by.count %}{{ used }} users{% endblocktrans %}</td>
+                    <td>{% if coupon.max_limit_usage != coupon.used_by.count %}<span class="badge bg-success">{% trans "Active" %}</span>{% else %}<span class="badge bg-danger">{% trans "Inactive" %}</span>{% endif %}</td>
                     
                    
                   </tr>
@@ -99,7 +100,7 @@
               <li class="page-item"><button class="page-link" href="?page={{ page_obj.next_page_number }}" onclick="changePage(`{{page_obj.next_page_number}}`)">{{ page_obj.next_page_number }}</button></li>
               {% endif %}
               {% if page_obj.number|add:'2' < page_obj.paginator.num_pages %}
-              <li class="page-item disabled"><a class="page-link" href="#">...</a></li>
+              <li class="page-item disabled"><a class="page-link" href="#">{% trans "..." %}</a></li>
               {% endif %}
               <li class="page-item"><button class="page-link" href="?page={{page_obj.paginator.num_pages}}" onclick="changePage(`{{page_obj.paginator.num_pages}}`)">{{page_obj.paginator.num_pages}}</button></li>
               <li class="page-item">

--- a/core/templates/dashboard/admin/home.html
+++ b/core/templates/dashboard/admin/home.html
@@ -1,12 +1,13 @@
 {% extends 'dashboard/admin/base.html' %}
 {% load static %}
+{% load i18n %}
 
 {% block breadcrumb %}
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb breadcrumb-light mb-0">
-        <li class="breadcrumb-item">حساب</li>
+        <li class="breadcrumb-item">{% trans "Account" %}</li>
         <li class="breadcrumb-item active" aria-current="page">
-            داشبورد ادمین
+            {% trans "Admin dashboard" %}
         </li>
     </ol>
 </nav>
@@ -17,17 +18,17 @@
 <div class="card">
     <!-- Header -->
     <div class="card-header border-bottom">
-        <h5 class="card-header-title">اطلاعات من</h5>
+        <h5 class="card-header-title">{% trans "My information" %}</h5>
     </div>
     <!-- End Header -->
 
     <div class="container mt-5">
-        <!-- <h1 class="mb-4 text-center">اطلاعات من</h1> -->
+        <!-- <h1 class="mb-4 text-center">My information</h1> -->
         <div class="row">
             <div class="col-md-6 mb-3">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">ایمیل</h5>
+                        <h5 class="card-title">{% trans "Email" %}</h5>
                         <p class="card-text">{{user_info.email}}</p>
                     </div>
                 </div>
@@ -35,7 +36,7 @@
             <div class="col-md-6 mb-3">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">نام و نام خانوادگی</h5>
+                        <h5 class="card-title">{% trans "Full name" %}</h5>
                         <p class="card-text">{{user_info.user_profile.get_fullname}}</p>
                     </div>
                 </div>
@@ -43,7 +44,7 @@
             <div class="col-md-6 mb-3">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">شماره تلفن</h5>
+                        <h5 class="card-title">{% trans "Phone number" %}</h5>
                         <p class="card-text">{{user_info.user_profile.phone_number}}</p>
                     </div>
                 </div>
@@ -51,8 +52,8 @@
             <div class="col-md-6 mb-3">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">نوع کاربر</h5>
-                        <p class="card-text">ادمین</p>
+                        <h5 class="card-title">{% trans "User type" %}</h5>
+                        <p class="card-text">{% trans "Admin" %}</p>
                     </div>
                 </div>
             </div>

--- a/core/templates/dashboard/admin/members/member-edit.html
+++ b/core/templates/dashboard/admin/members/member-edit.html
@@ -1,11 +1,12 @@
 {% extends "dashboard/admin/base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
 <div class="card">
     <!-- Header -->
     <div class="card-header border-bottom">
-      <h5 class="card-header-title">ساخت کد تخفیف</h5>
+      <h5 class="card-header-title">{% trans "Create discount code" %}</h5>
     </div>
     <!-- End Header -->
 
@@ -15,17 +16,17 @@
         {% csrf_token %}
         <div class="form-check form-switch">
             {{form.is_active}}
-            <label class="form-check-label" for="flexSwitchCheckDefault">دسترسی کاربر به سایت ( با غیر فعال کردن این گزینه ، کاربر دیگر قادر به ورود به اکانت خود نیست )</label>
+            <label class="form-check-label" for="flexSwitchCheckDefault">{% trans "User access to the site (disabling this option prevents the user from logging into their account)" %}</label>
           </div>
           <br>
         <div class="form-check form-switch">
             {{form.is_verified}}
-            <label class="form-check-label" for="flexSwitchCheckDefault">صحت ایمیل کاربر ( در حال ساخت )</label>
+            <label class="form-check-label" for="flexSwitchCheckDefault">{% trans "User email verification (under construction)" %}</label>
           </div>
 
           <div class=" d-flex pt-5 justify-content-end">
-            <a class="btn btn-secondary ms-3" href="{% url 'dashboard:admin:member-list' %}">بازگشت</a>
-            <button type="submit" class="btn btn-primary ms-3">ویرایش</button>
+            <a class="btn btn-secondary ms-3" href="{% url 'dashboard:admin:member-list' %}">{% trans "Back" %}</a>
+            <button type="submit" class="btn btn-primary ms-3">{% trans "Edit" %}</button>
           </div>
         </div>
     </form>

--- a/core/templates/dashboard/admin/members/member-list.html
+++ b/core/templates/dashboard/admin/members/member-list.html
@@ -1,5 +1,6 @@
 {% extends "dashboard/admin/base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
     <!-- Card -->
@@ -7,7 +8,7 @@
         <!-- Header -->
         <div class="card-header border-bottom">
           <div class="d-flex justify-content-between align-items-center">
-            <h5 class="">لیست کاربران</h5>
+            <h5 class="">{% trans "User list" %}</h5>
           </div>
         </div>
         <!-- End Header -->
@@ -19,14 +20,14 @@
 
               <!-- Input Card -->
               <div class="col-md-5 py-1">
-                <input type="text" class="form-control" placeholder="جستجوی" aria-label="جستجوی ایمیل" name="q" id="search-query-filter">
+                <input type="text" class="form-control" placeholder="{% trans 'Search' %}" aria-label="{% trans 'Search email' %}" name="q" id="search-query-filter">
 
               </div>
               <!-- End Input Card -->
               <div class="col-md-3 py-1">
                 <select class="form-select" name="order_by" id="order-by-filter">
-                  <option value="-created_date">جدیدترین</option>
-                  <option value="created_date">قدیمی ترین</option>
+                  <option value="-created_date">{% trans "Newest" %}</option>
+                  <option value="created_date">{% trans "Oldest" %}</option>
                 </select>
               </div>
               <div class="col-md-1 py-1">
@@ -43,11 +44,11 @@
                 <thead class="thead-light">
                   <tr>
                     <th scope="col">#</th>
-                    <th scope="col">ایمیل</th>
-                    <th scope="col">دسترسی</th>
-                    <th scope="col">فعال</th>
-                    <th scope="col">نوع کاربر</th>
-                    <th scope="col">ویرایش</th>
+                    <th scope="col">{% trans "Email" %}</th>
+                    <th scope="col">{% trans "Access" %}</th>
+                    <th scope="col">{% trans "Active" %}</th>
+                    <th scope="col">{% trans "User type" %}</th>
+                    <th scope="col">{% trans "Edit" %}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -55,9 +56,9 @@
                   <tr>
                     <th scope="row">{{forloop.counter}}</th>
                     <td>{{member.email}}</td>
-                    <td>{% if member.is_active == True %}<span class="badge bg-success">فعال</span>{% else %}<span class="badge bg-danger">غیر فعال</span>{% endif %}</td>
-                    <td>{% if member.is_verified == True %}<span class="badge bg-success">فعال</span>{% else %}<span class="badge bg-danger">غیر فعال</span>{% endif %}</td>
-                    <td>{% if member.user_type == 2 %}<span class="badge bg-success">ادمین</span>{% else %}<span class="badge bg-danger">عادی</span>{% endif %}</td>
+                    <td>{% if member.is_active == True %}<span class="badge bg-success">{% trans "Active" %}</span>{% else %}<span class="badge bg-danger">{% trans "Inactive" %}</span>{% endif %}</td>
+                    <td>{% if member.is_verified == True %}<span class="badge bg-success">{% trans "Active" %}</span>{% else %}<span class="badge bg-danger">{% trans "Inactive" %}</span>{% endif %}</td>
+                    <td>{% if member.user_type == 2 %}<span class="badge bg-success">{% trans "Admin" %}</span>{% else %}<span class="badge bg-danger">{% trans "Regular" %}</span>{% endif %}</td>
                     <td>
                         <a class="btn btn-sm btn-icon btn-ghost-secondary" href="{% url 'dashboard:admin:member-edit' pk=member.id %}"><i class="bi-pencil-square"></i></a>
                     </td>
@@ -92,7 +93,7 @@
               <li class="page-item"><button class="page-link" href="?page={{ page_obj.next_page_number }}" onclick="changePage(`{{page_obj.next_page_number}}`)">{{ page_obj.next_page_number }}</button></li>
               {% endif %}
               {% if page_obj.number|add:'2' < page_obj.paginator.num_pages %}
-              <li class="page-item disabled"><a class="page-link" href="#">...</a></li>
+              <li class="page-item disabled"><a class="page-link" href="#">{% trans "..." %}</a></li>
               {% endif %}
               <li class="page-item"><button class="page-link" href="?page={{page_obj.paginator.num_pages}}" onclick="changePage(`{{page_obj.paginator.num_pages}}`)">{{page_obj.paginator.num_pages}}</button></li>
               <li class="page-item">

--- a/core/templates/dashboard/admin/orders/list.html
+++ b/core/templates/dashboard/admin/orders/list.html
@@ -1,11 +1,12 @@
 {% extends "dashboard/admin/base.html" %}
 {% load static %}
 {% load humanize %}
+{% load i18n %}
 {% block content %}
 <div class="card">
     <!-- Header -->
     <div class="card-header border-bottom">
-      <h5 class="card-header-title">لیست سفارشات</h5>
+      <h5 class="card-header-title">{% trans "Order list" %}</h5>
     </div>
     <!-- End Header -->
 
@@ -19,11 +20,11 @@
             <thead class="thead-light">
               <tr>
                 <th scope="col">#</th>
-                <th scope="col">شماره سفارش</th>
-                <th scope="col">سفارش دهنده</th>
-                <th scope="col">قیمت کل</th>
-                <th scope="col">تاریخ ثبت</th>
-                <th scope="col">وضعیت</th>
+                <th scope="col">{% trans "Order number" %}</th>
+                <th scope="col">{% trans "Customer" %}</th>
+                <th scope="col">{% trans "Total price" %}</th>
+                <th scope="col">{% trans "Created date" %}</th>
+                <th scope="col">{% trans "Status" %}</th>
                 
               </tr>
             </thead>
@@ -75,7 +76,7 @@
             <li class="page-item"><button class="page-link" href="?page={{ page_obj.next_page_number }}" onclick="changePage(`{{page_obj.next_page_number}}`)">{{ page_obj.next_page_number }}</button></li>
             {% endif %}
             {% if page_obj.number|add:'2' < page_obj.paginator.num_pages %}
-            <li class="page-item disabled"><a class="page-link" href="#">...</a></li>
+            <li class="page-item disabled"><a class="page-link" href="#">{% trans "..." %}</a></li>
             {% endif %}
             <li class="page-item"><button class="page-link" href="?page={{page_obj.paginator.num_pages}}" onclick="changePage(`{{page_obj.paginator.num_pages}}`)">{{page_obj.paginator.num_pages}}</button></li>
             <li class="page-item">

--- a/core/templates/dashboard/admin/orders/single.html
+++ b/core/templates/dashboard/admin/orders/single.html
@@ -1,6 +1,7 @@
 {% extends "dashboard/customer/base.html" %}
 {% load static %}
 {% load humanize %}
+{% load i18n %}
 
 {% block content %}
 
@@ -9,8 +10,8 @@
     <!-- Header -->
     <div class="card-header border-bottom">
       <div class="d-flex justify-content-between align-items-center">
-        <h5 class="">شماره سفارش : {{order.id}}</h5>
-        <a class="btn btn-primary" href="{% url 'dashboard:customer:order-invoice' pk=order.id %}" target="_blank">مشاهده فاکتور</a>
+        <h5 class="">{% blocktrans with order_id=order.id %}Order number : {{ order_id }}{% endblocktrans %}</h5>
+        <a class="btn btn-primary" href="{% url 'dashboard:customer:order-invoice' pk=order.id %}" target="_blank">{% trans "View invoice" %}</a>
       </div>
     </div>
     <!-- End Header -->
@@ -25,10 +26,10 @@
             <thead class="thead-light">
               <tr>
                 <th scope="col">#</th>
-                <th scope="col">تصویر</th>
-                <th scope="col">کد محصول</th>
-                <th scope="col">نام محصول</th>
-                <th scope="col">تعداد سفارش</th>
+                <th scope="col">{% trans "Image" %}</th>
+                <th scope="col">{% trans "Product code" %}</th>
+                <th scope="col">{% trans "Product name" %}</th>
+                <th scope="col">{% trans "Quantity ordered" %}</th>
               </tr>
             </thead>
             {% for product in order.order_items.all %}
@@ -42,7 +43,7 @@
                 </td>
                 <td>{{product.product.id}}</td>
                 <td>{{product.product.title}}</td>
-                <td>{{product.quantity}} عدد</td>
+                <td>{% blocktrans count quantity=product.quantity %}{{ quantity }} item{% plural %}{{ quantity }} items{% endblocktrans %}</td>
               </tr>
             </tbody>
             {% endfor %}
@@ -58,32 +59,32 @@
     <div class="card-footer row pt-5 mt-5">
       <form>
         <div class="row mb-3 align-items-center">
-          <dt class="col-md-3">سفارش دهنده:</dt>
+          <dt class="col-md-3">{% trans "Customer:" %}</dt>
           <dl class="col-md-3">{{order.user.user_profile.get_fullname}}</dl>
-          <dt class="col-md-3">وضعیت سفارش:</dt>
+          <dt class="col-md-3">{% trans "Order status:" %}</dt>
           <dl class="col-md-3 ">{{order.get_status.label}}</dl>
         </div>
         <div class="row mb-3">
-          <dt class="col-md-3"> تاریخ سفارش:</dt>
+          <dt class="col-md-3">{% trans "Order date:" %}</dt>
           <dl class="col-md-3">{{order.created_date|date:'Y-m-d h:i'}}</dl>
-          <dt class="col-md-3"> درصد تخفیف:</dt>
+          <dt class="col-md-3">{% trans "Discount percentage:" %}</dt>
           <dl class="col-md-3">{{order.coupon.discount_percent}}</dl>
         </div>
         <!-- End Row -->
         <div class="row mb-3">
-          <dt class="col-md-3"> کد پستی:</dt>
+          <dt class="col-md-3">{% trans "Postal code:" %}</dt>
           <dl class="col-md-3">{{order.address.zip_code}}</dl>
-          <dt class="col-md-3"> قیمت اصلی:</dt>
-          <dl class="col-md-3">{{order.get_totalprice|intcomma}} تومان</dl>
+          <dt class="col-md-3">{% trans "Original price:" %}</dt>
+          <dl class="col-md-3">{{order.get_totalprice|intcomma}} {% trans "Toman" %}</dl>
         </div>
         <div class="row mb-3">
-          <dt class="col-md-3"> آدرس:</dt>
+          <dt class="col-md-3">{% trans "Address:" %}</dt>
           <dl class="col-md-3">{{order.get_fulladdress}}</dl>
-          <dt class="col-md-3"> قیمت با تخفیف:</dt>
-          <dl class="col-md-3">{{order.final_price|intcomma}} تومان</dl>
+          <dt class="col-md-3">{% trans "Discounted price:" %}</dt>
+          <dl class="col-md-3">{{order.final_price|intcomma}} {% trans "Toman" %}</dl>
         </div>
         <div class=" d-flex pt-5 justify-content-end">
-          <a class="btn btn-secondary ms-3" href="{% url 'dashboard:admin:orders-list' %}">بازگشت</a>
+          <a class="btn btn-secondary ms-3" href="{% url 'dashboard:admin:orders-list' %}">{% trans "Back" %}</a>
         </div>
       </form>
     </div>

--- a/core/templates/dashboard/admin/products/create-product.html
+++ b/core/templates/dashboard/admin/products/create-product.html
@@ -1,11 +1,12 @@
 {% extends "dashboard/admin/base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
 <div class="card">
     <!-- Header -->
     <div class="card-header border-bottom">
-      <h5 class="card-header-title">ویرایش/ساخت محصول</h5>
+      <h5 class="card-header-title">{% trans "Edit/Create product" %}</h5>
     </div>
     <!-- End Header -->
 
@@ -15,51 +16,51 @@
         {% csrf_token %}
         <div class="row d-flex ">
           <div class="col-md-6 mb-3">
-            <label >نام محصول</label>
+            <label >{% trans "Product name" %}</label>
             {{form.title}}
           </div>
           <div class="col-md-6 mb-3">
-            <label>اسلاگ محصول</label>
+            <label>{% trans "Product slug" %}</label>
             {{form.slug}}
           </div>
           <div class="col-md-6 mb-3">
-            <label>تعداد</label>
+            <label>{% trans "Quantity" %}</label>
             {{form.stock}}
           </div>
 
           <div class="col-md-6 mb-3">
-            <label>وضعیت</label>
+            <label>{% trans "Status" %}</label>
             {{form.status}}
           </div>
           <div class="col-md-6 mb-3">
-            <label for="cat-id">دسته بندی</label>
+            <label for="cat-id">{% trans "Category" %}</label>
             <br>
             {{form.category}}
         </div>
           <div class="col-md-4 mb-3">
-            <label>قیمت</label>
+            <label>{% trans "Price" %}</label>
             {{form.price}}
           </div>
           <div class="col-md-2 mb-3">
-            <label>درصد تخفیف</label>
+            <label>{% trans "Discount percentage" %}</label>
             {{form.discount_percent}}
           </div>
 
           <div class="col-md-12 mb-3">
-            <label>توضیحات</label>
+            <label>{% trans "Description" %}</label>
             {{ form.media }}
             {{form.description}}
           </div>
 
 
           <div class="col-md-12 mb-3">
-            <label>تصویر محصول</label>
+            <label>{% trans "Product image" %}</label>
             {{image_form.images}}
           </div>
 
           <div class=" d-flex pt-5 justify-content-end">
-            <a class="btn btn-secondary ms-3" href="{% url 'dashboard:admin:show-prod' %}">بازگشت</a>
-            <button type="submit" class="btn btn-primary ms-3">ثبت محصول</button>
+            <a class="btn btn-secondary ms-3" href="{% url 'dashboard:admin:show-prod' %}">{% trans "Back" %}</a>
+            <button type="submit" class="btn btn-primary ms-3">{% trans "Submit product" %}</button>
           </div>
         </div>
     </form>

--- a/core/templates/dashboard/admin/products/delete-prod.html
+++ b/core/templates/dashboard/admin/products/delete-prod.html
@@ -1,22 +1,23 @@
 {% extends "dashboard/admin/base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
 <div class="card">
     <!-- Header -->
     <div class="card-header border-bottom">
-        <h5 class="card-header-title">حذف محصول</h5>
+        <h5 class="card-header-title">{% trans "Delete product" %}</h5>
     </div>
     <!-- End Header -->
 
     <form action="." method="post">{% csrf_token %}
         <div class="card-body">
-            <p>آیا مطمئن هستید که می‌خواهید این محصول را حذف کنید؟ این عمل قابل بازگشت نیست.</p>
+            <p>{% trans "Are you sure you want to delete this product? This action cannot be undone." %}</p>
         </div>
         <div class="card-footer d-flex justify-content-end">
-            <a class="btn btn-secondary me-3" href="{% url 'dashboard:admin:edit-prod' pk=object.pk %}">بازگشت</a>
+            <a class="btn btn-secondary me-3" href="{% url 'dashboard:admin:edit-prod' pk=object.pk %}">{% trans "Back" %}</a>
             <span class="mx-2"></span> <!-- Added this for spacing -->
-            <button class="btn btn-danger">حذف</button>
+            <button class="btn btn-danger">{% trans "Delete" %}</button>
         </div>
     </form>
 </div>

--- a/core/templates/dashboard/admin/products/edit-products.html
+++ b/core/templates/dashboard/admin/products/edit-products.html
@@ -1,11 +1,12 @@
 {% extends "dashboard/admin/base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
 <div class="card">
     <!-- Header -->
     <div class="card-header border-bottom">
-      <h5 class="card-header-title">ویرایش/ساخت محصول</h5>
+      <h5 class="card-header-title">{% trans "Edit/Create product" %}</h5>
     </div>
     <!-- End Header -->
 
@@ -15,38 +16,38 @@
         {% csrf_token %}
         <div class="row d-flex ">
           <div class="col-md-6 mb-3">
-            <label >نام محصول</label>
+            <label >{% trans "Product name" %}</label>
             {{form.title}}
           </div>
           <div class="col-md-6 mb-3">
-            <label>اسلاگ محصول</label>
+            <label>{% trans "Product slug" %}</label>
             {{form.slug}}
           </div>
           <div class="col-md-6 mb-3">
-            <label>تعداد</label>
+            <label>{% trans "Quantity" %}</label>
             {{form.stock}}
           </div>
 
           <div class="col-md-6 mb-3">
-            <label>وضعیت</label>
+            <label>{% trans "Status" %}</label>
             {{form.status}}
           </div>
           <div class="col-md-6 mb-3">
-            <label for="cat-id">دسته بندی</label>
+            <label for="cat-id">{% trans "Category" %}</label>
             <br>
             {{form.category}}
         </div>
           <div class="col-md-4 mb-3">
-            <label>قیمت</label>
+            <label>{% trans "Price" %}</label>
             {{form.price}}
           </div>
           <div class="col-md-2 mb-3">
-            <label>درصد تخفیف</label>
+            <label>{% trans "Discount percentage" %}</label>
             {{form.discount_percent}}
           </div>
 
           <div class="col-md-12 mb-3">
-            <label>توضیحات</label>
+            <label>{% trans "Description" %}</label>
             {{form.description}}
             <!-- <div class="quill-custom">
                 <div class="js-quill" style="height: 15rem;" data-hs-quill-options='{
@@ -56,20 +57,20 @@
                           ["bold", "italic", "underline", "strike", "link", "image", "blockquote", "code", {"list": "bullet"}]
                         ]
                       }
-                     }'>ذهن خلاق در Htmlstream
+                     }'>Creative mind at Htmlstream
                 </div>
             </div> -->
           </div>
 
           <div class="col-md-12 mb-3">
-            <label>تصویر محصول</label>
+            <label>{% trans "Product image" %}</label>
             {{form.image}}
           </div>
 
           <div class=" d-flex pt-5 justify-content-end">
-            <a class="btn btn-danger ms-3" href="{% url 'dashboard:admin:delete-prod' pk=object.pk %}">حذف</a>
-            <a class="btn btn-secondary ms-3" href="{% url 'dashboard:admin:show-prod' %}">بازگشت</a>
-            <button type="submit" class="btn btn-primary ms-3">ثبت تغییرات</button>
+            <a class="btn btn-danger ms-3" href="{% url 'dashboard:admin:delete-prod' pk=object.pk %}">{% trans "Delete" %}</a>
+            <a class="btn btn-secondary ms-3" href="{% url 'dashboard:admin:show-prod' %}">{% trans "Back" %}</a>
+            <button type="submit" class="btn btn-primary ms-3">{% trans "Save changes" %}</button>
           </div>
         </div>
     </form>

--- a/core/templates/dashboard/admin/products/show-products.html
+++ b/core/templates/dashboard/admin/products/show-products.html
@@ -1,6 +1,7 @@
 {% extends "dashboard/admin/base.html" %}
 {% load static %}
 {% load humanize %}
+{% load i18n %}
 
 {% block content %}
     <!-- Card -->
@@ -8,8 +9,8 @@
         <!-- Header -->
         <div class="card-header border-bottom">
           <div class="d-flex justify-content-between align-items-center">
-            <h5 class="">لیست محصولات</h5>
-            <a class="btn btn-primary" href="{% url 'dashboard:admin:create-prod' %}">اضافه کردن</a>
+            <h5 class="">{% trans "Product list" %}</h5>
+            <a class="btn btn-primary" href="{% url 'dashboard:admin:create-prod' %}">{% trans "Add" %}</a>
           </div>
         </div>
         <!-- End Header -->
@@ -21,19 +22,19 @@
 
               <!-- Input Card -->
               <div class="col-md-5 py-1">
-                <input type="text" class="form-control" placeholder="جستجوی" aria-label="جستجوی ایمیل" name="q" id="search-query-filter">
+                <input type="text" class="form-control" placeholder="{% trans 'Search' %}" aria-label="{% trans 'Search email' %}" name="q" id="search-query-filter">
 
               </div>
               <!-- End Input Card -->
               <div class="col-md-3 py-1">
                 <select class="form-select" name="order_by" id="order-by-filter">
-                  <option value="-created_date">جدیدترین</option>
-                  <option value="created_date">قدیمی ترین</option>
+                  <option value="-created_date">{% trans "Newest" %}</option>
+                  <option value="created_date">{% trans "Oldest" %}</option>
                 </select>
               </div>
               <div class="col-md-3 py-1">
                 <select class="form-select" name="category_id" id="category-id-filter">
-                    <option value="" selected>انتخاب دسته بندی</option>
+                    <option value="" selected>{% trans "Select category" %}</option>
                     {% for category in categories %}
                     <option value="{{category.id}}">{{category.title}}</option>
                     {% endfor %}
@@ -53,13 +54,13 @@
                 <thead class="thead-light">
                   <tr>
                     <th scope="col">#</th>
-                    <th scope="col">نام محصول</th>
-                    <th scope="col">دسته بندی</th>
-                    <th scope="col">قیمت</th>
-                    <th scope="col">تعداد</th>
-                    <th scope="col">وضعیت</th>
-                    <th scope="col">تخفیف</th>
-                    <th scope="col">عملیات</th>
+                    <th scope="col">{% trans "Product name" %}</th>
+                    <th scope="col">{% trans "Category" %}</th>
+                    <th scope="col">{% trans "Price" %}</th>
+                    <th scope="col">{% trans "Quantity" %}</th>
+                    <th scope="col">{% trans "Status" %}</th>
+                    <th scope="col">{% trans "Discount" %}</th>
+                    <th scope="col">{% trans "Actions" %}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -70,7 +71,7 @@
                     <td>{% for cat in object.category.all %}{{cat.title}}{% if not forloop.last %},{% endif %}{% endfor %}</td>
                     <td>{{object.price|intcomma}}</td>
                     <td>{{object.stock}}</td>
-                    <td>{% if object.is_published %}<span class="badge bg-success">نشر شده</span>{% else %}<span class="badge bg-danger">زخیره شده</span>{% endif %}</td>
+                    <td>{% if object.is_published %}<span class="badge bg-success">{% trans "Published" %}</span>{% else %}<span class="badge bg-danger">{% trans "Saved" %}</span>{% endif %}</td>
                     <td>{{object.discount_percent}}%</td>
                     <td>
                       <a class="btn btn-sm btn-icon btn-ghost-secondary" href="{% url 'dashboard:admin:edit-prod' pk=object.id %}"><i class="bi-pencil-square"></i></a>
@@ -106,7 +107,7 @@
               <li class="page-item"><button class="page-link" href="?page={{ page_obj.next_page_number }}" onclick="changePage(`{{page_obj.next_page_number}}`)">{{ page_obj.next_page_number }}</button></li>
               {% endif %}
               {% if page_obj.number|add:'2' < page_obj.paginator.num_pages %}
-              <li class="page-item disabled"><a class="page-link" href="#">...</a></li>
+              <li class="page-item disabled"><a class="page-link" href="#">{% trans "..." %}</a></li>
               {% endif %}
               <li class="page-item"><button class="page-link" href="?page={{page_obj.paginator.num_pages}}" onclick="changePage(`{{page_obj.paginator.num_pages}}`)">{{page_obj.paginator.num_pages}}</button></li>
               <li class="page-item">

--- a/core/templates/dashboard/admin/profile/change-pass.html
+++ b/core/templates/dashboard/admin/profile/change-pass.html
@@ -1,11 +1,12 @@
 {% extends 'dashboard/admin/base.html' %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
 <!-- Card -->
 <div class="card mb-3">
     <div class="card-header border-bottom">
-        <h5 class="card-header-title">رمزعبور</h5>
+        <h5 class="card-header-title">{% trans "Password" %}</h5>
     </div>
 
     <!-- Body -->
@@ -14,47 +15,46 @@
         <form action="." method="post">{% csrf_token %}
             <!-- Form -->
             <div class="row mb-4">
-              <label for="currentPasswordLabel" class="col-sm-3 col-form-label form-label">رمز عبور فعلی</label>
+              <label for="currentPasswordLabel" class="col-sm-3 col-form-label form-label">{% trans "Current password" %}</label>
 
               <div class="col-sm-9">
                 <input type="password" class="form-control" name="old_password" id="currentPasswordLabel"
-                  placeholder="Enter current password" aria-label="Enter current password">
+                  placeholder="{% trans 'Enter current password' %}" aria-label="{% trans 'Enter current password' %}">
               </div>
             </div>
             <!-- End Form -->
 
             <!-- Form -->
             <div class="row mb-4">
-              <label for="newPassword" class="col-sm-3 col-form-label form-label">رمز عبور جدید</label>
+              <label for="newPassword" class="col-sm-3 col-form-label form-label">{% trans "New password" %}</label>
 
               <div class="col-sm-9">
                 <input type="password" class="form-control" name="new_password1" id="newPassword"
-                  placeholder="Enter new password" aria-label="Enter new password">
+                  placeholder="{% trans 'Enter new password' %}" aria-label="{% trans 'Enter new password' %}">
               </div>
             </div>
             <!-- End Form -->
 
             <!-- Form -->
             <div class="row mb-4">
-              <label for="confirmNewPasswordLabel" class="col-sm-3 col-form-label form-label">رمز عبور جدید را
-                تایید کنید</label>
+              <label for="confirmNewPasswordLabel" class="col-sm-3 col-form-label form-label">{% trans "Confirm new password" %}</label>
 
               <div class="col-sm-9">
                 <div class="mb-3">
                   <input type="password" class="form-control" name="new_password2"
-                    id="confirmNewPasswordLabel" placeholder="Confirm your new password"
-                    aria-label="Confirm your new password">
+                    id="confirmNewPasswordLabel" placeholder="{% trans 'Confirm your new password' %}"
+                    aria-label="{% trans 'Confirm your new password' %}">
                 </div>
 
-                <h5>الزامات رمز عبور:</h5>
+                <h5>{% trans "Password requirements:" %}</h5>
 
-                <p class="card-text small">اطمینان حاصل کنید که این الزامات برآورده شده است:</p>
+                <p class="card-text small">{% trans "Make sure these requirements are met:" %}</p>
 
                 <ul class="small">
-                  <li>حداقل 8 کاراکتر - هر چه بیشتر باشد، بهتر است</li>
-                  <li>حداقل یک نویسه کوچک</li>
-                  <li>حداقل یک کاراکتر بزرگ</li>
-                  <li>حداقل یک عدد، نماد یا نویسه فضای خالی</li>
+                  <li>{% trans "Minimum 8 characters – the more, the better" %}</li>
+                  <li>{% trans "At least one lowercase character" %}</li>
+                  <li>{% trans "At least one uppercase character" %}</li>
+                  <li>{% trans "At least one number, symbol, or whitespace character" %}</li>
                 </ul>
               </div>
             </div>
@@ -62,7 +62,7 @@
 
 
             <div class="d-flex justify-content-end gap-3">
-                <button type="submit" class="btn btn-primary">بروزرسانی</button>
+                <button type="submit" class="btn btn-primary">{% trans "Update" %}</button>
             </div>
         </form>
         <!-- End Form -->
@@ -74,13 +74,12 @@
 <!-- Card -->
 <div class="card mb-3">
     <div class="card-header border-bottom">
-        <h5 class="card-header-title">حساب های متصل</h5>
+        <h5 class="card-header-title">{% trans "Connected accounts" %}</h5>
     </div>
 
     <!-- Body -->
     <div class="card-body">
-        <p class="card-text">ویژگی‌های یکپارچه این حساب‌ها، همکاری با افرادی را که در Front می‌شناسید آسان‌تر
-            می‌کند.</p>
+        <p class="card-text">{% trans "The integrated features of these accounts make it easier to collaborate with the people you know in Front." %}</p>
 
         <!-- Form -->
         <form>
@@ -97,8 +96,8 @@
                         <div class="flex-grow-1 me-3">
                             <div class="row align-items-center">
                                 <div class="col ">
-                                    <h6 class="mb-1 ">گوگل</h6>
-                                    <span class="d-block small text-body">تقویم و مخاطبین</span>
+                                    <h6 class="mb-1 ">{% trans "Google" %}</h6>
+                                    <span class="d-block small text-body">{% trans "Calendar and contacts" %}</span>
                                 </div>
                                 <!-- End Col -->
 

--- a/core/templates/dashboard/admin/profile/profile.html
+++ b/core/templates/dashboard/admin/profile/profile.html
@@ -1,10 +1,11 @@
 {% extends "dashboard/admin/base.html" %}
 {% load static %}
+{% load i18n %}
 {% block content %}
           <!-- Card -->
           <div class="card">
             <div class="card-header border-bottom">
-              <h4 class="card-header-title">اطلاعات پایه</h4>
+              <h4 class="card-header-title">{% trans "Basic information" %}</h4>
             </div>
 
             <!-- Body -->
@@ -14,7 +15,7 @@
 
                 <!-- Form -->
                 <div class="row mb-4">
-                  <label for="firstNameLabel" class="col-sm-3 col-form-label form-label">نام و نام خانوادگی </label>
+                  <label for="firstNameLabel" class="col-sm-3 col-form-label form-label">{% trans "Full name" %} </label>
 
                   <div class="col-sm-9">
                     <div class="input-group">
@@ -31,8 +32,8 @@
                         "container": "#addPhoneFieldContainer",
                         "defaultCreated": 0
                       }'>
-                  <label for="phoneLabel" class="col-sm-3 col-form-label form-label">تلفن <span
-                      class="form-label-secondary">(اختیاری)</span></label>
+                  <label for="phoneLabel" class="col-sm-3 col-form-label form-label">{% trans "Phone" %} <span
+                      class="form-label-secondary">{% trans "(Optional)" %}</span></label>
 
                   <div class="col-sm-9">
                     <div class="input-group">
@@ -46,7 +47,7 @@
             <!-- End Form -->
             <!-- Footer -->
               <div class="d-flex justify-content-end gap-3">
-                <button type="submit" class="btn btn-primary">ذخیره تغییرات</button>
+                <button type="submit" class="btn btn-primary">{% trans "Save changes" %}</button>
               </div>
             <!-- End Footer -->
               </form>

--- a/core/templates/dashboard/admin/sidebar.html
+++ b/core/templates/dashboard/admin/sidebar.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load i18n %}
 <!-- Navbar -->
  <div class="navbar-expand-lg navbar-light">
     <div id="sidebarNav" class="collapse navbar-collapse navbar-vertical">
@@ -18,75 +19,75 @@
               <h4 class="card-title mb-0">{{request.user.user_profile.get_fullname}}</h4>
               <p class="card-text small">{{request.user.email}}</p>
               <br>
-              <button type="submit" class="btn btn-primary">ذخیره پروفایل</button>
+              <button type="submit" class="btn btn-primary">{% trans "Save profile" %}</button>
             </form>
           </div>
           <!-- End Avatar -->
 
           <!-- Nav -->
-          <span class="text-cap">حساب</span>
+          <span class="text-cap">{% trans "Account" %}</span>
 
           <!-- List -->
           <ul class="nav nav-sm nav-tabs nav-vertical mb-4">
             <li class="nav-item">
               <a class="nav-link" href="{% url 'dashboard:admin:home' %}">
-                <i class="bi-person-badge nav-icon"></i>داشبورد
+                <i class="bi-person-badge nav-icon"></i> {% trans "Dashboard" %}
               </a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="{% url 'dashboard:admin:change-pass' %}">
-                <i class="bi-shield-shaded nav-icon"></i> امنیت
+                <i class="bi-shield-shaded nav-icon"></i> {% trans "Security" %}
               </a>
             </li>
 
             <li class="nav-item">
               <a class="nav-link" href="{% url 'dashboard:admin:profile' %}">
-                <i class="bi-sliders nav-icon"></i> تنظیمات پروفایل
+                <i class="bi-sliders nav-icon"></i> {% trans "Profile settings" %}
               </a>
             </li>
           </ul>
           <!-- End List -->
 
-          <span class="text-cap">فروشگاه</span>
+          <span class="text-cap">{% trans "Store" %}</span>
 
           <!-- List -->
           <ul class="nav nav-sm nav-tabs nav-vertical mb-4">
             <li class="nav-item">
               <a class="nav-link " href="{% url 'dashboard:admin:show-prod' %}">
-                <i class="bi-shop-window nav-icon"></i> محصولات
+                <i class="bi-shop-window nav-icon"></i> {% trans "Products" %}
               </a>
             </li>
             <li class="nav-item">
               <a class="nav-link " href="{% url 'dashboard:admin:orders-list' %}">
-                <i class="bi-receipt-cutoff nav-icon"></i> سفارشات
+                <i class="bi-receipt-cutoff nav-icon"></i> {% trans "Orders" %}
               </a>
             </li>
             <li class="nav-item">
               <a class="nav-link " href="{% url 'dashboard:admin:coupon-list' %}">                
-                <i class="bi-ticket-perforated nav-icon"></i> کد تخفیف
+                <i class="bi-ticket-perforated nav-icon"></i> {% trans "Discount code" %}
               </a>
             </li>
             <li class="nav-item">
               <a class="nav-link " href="{% url 'dashboard:admin:ticket-list' %}">
-                <i class="bi-envelope nav-icon"></i> تیکت ها
+                <i class="bi-envelope nav-icon"></i> {% trans "Tickets" %}
               </a>
             </li>
 
 
           </ul>
 
-          <span class="text-cap">کاربران</span>
+          <span class="text-cap">{% trans "Users" %}</span>
 
           <!-- List -->
           <ul class="nav nav-sm nav-tabs nav-vertical mb-4">
             <li class="nav-item">
               <a class="nav-link " href="{% url 'dashboard:admin:member-list' %}">
-                <i class="bi-person nav-icon"></i> لیست کاربران
+                <i class="bi-person nav-icon"></i> {% trans "User list" %}
               </a>
             </li>
             <li class="nav-item">
               <a class="nav-link " href="#">
-                <i class="bi-newspaper nav-icon"></i> خبرنامه
+                <i class="bi-newspaper nav-icon"></i> {% trans "Newsletter" %}
               </a>
             </li>
 
@@ -101,7 +102,7 @@
             <ul class="nav nav-sm nav-tabs nav-vertical">
               <li class="nav-item">
                 <a class="nav-link" href="#">
-                  <i class="bi-box-arrow-right nav-icon"></i> خروج
+                  <i class="bi-box-arrow-right nav-icon"></i> {% trans "Log out" %}
                 </a>
               </li>
             </ul>

--- a/core/templates/dashboard/admin/tickets/ticket-delete.html
+++ b/core/templates/dashboard/admin/tickets/ticket-delete.html
@@ -1,22 +1,23 @@
 {% extends "dashboard/admin/base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
 <div class="card">
     <!-- Header -->
     <div class="card-header border-bottom">
-        <h5 class="card-header-title">حذف تیکت</h5>
+        <h5 class="card-header-title">{% trans "Delete ticket" %}</h5>
     </div>
     <!-- End Header -->
 
     <form action="." method="post">{% csrf_token %}
         <div class="card-body">
-            <p>آیا مطمئن هستید که می‌خواهید این تیکت را حذف کنید؟ این عمل قابل بازگشت نیست.</p>
+            <p>{% trans "Are you sure you want to delete this ticket? This action cannot be undone." %}</p>
         </div>
         <div class="card-footer d-flex justify-content-end">
-            <a class="btn btn-secondary me-3" href="{% url 'dashboard:admin:edit-prod' pk=object.pk %}">بازگشت</a>
+            <a class="btn btn-secondary me-3" href="{% url 'dashboard:admin:edit-prod' pk=object.pk %}">{% trans "Back" %}</a>
             <span class="mx-2"></span> <!-- Added this for spacing -->
-            <button class="btn btn-danger">حذف</button>
+            <button class="btn btn-danger">{% trans "Delete" %}</button>
         </div>
     </form>
 </div>

--- a/core/templates/dashboard/admin/tickets/ticket-detail.html
+++ b/core/templates/dashboard/admin/tickets/ticket-detail.html
@@ -1,11 +1,12 @@
 {% extends "dashboard/admin/base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
 <div class="card">
     <!-- Header -->
     <div class="card-header border-bottom">
-      <h5 class="card-header-title"> تیکت شماره 12345</h5>
+      <h5 class="card-header-title">{% blocktrans with ticket_id=ticket.id %}Ticket number {{ ticket_id }}{% endblocktrans %}</h5>
     </div>
     <!-- End Header -->
 
@@ -14,19 +15,19 @@
 
         <div class="row d-flex align-items-center">
           <div class="col-md-6 mb-3">
-            <dt>ایمیل: </dt>
+            <dt>{% trans "Email:" %} </dt>
             <dl>{{ticket.email}}</dl>
           </div>
           <div class="col-md-6 mb-3">
-            <dt>نام و نام خانوادگی: </dt>
+            <dt>{% trans "Full name:" %} </dt>
             <dl>{{ticket.name}} {{ticket.last_name}}</dl>
           </div>
           <div class="col-md-6 mb-3">
-            <dt>شماره تماس: </dt>
+            <dt>{% trans "Phone number:" %} </dt>
             <dl>{{ticket.phone_number}}</dl>
           </div>
           <div class="col-md-12 mb-3">
-            <dt>متن:</dt>
+            <dt>{% trans "Message:" %}</dt>
             <dl>
               <p>
                 {{ticket.description}}
@@ -40,8 +41,8 @@
       <div class="card-footer row pt-5 mt-5">
 
         <div class=" d-flex pt-5 justify-content-end">
-          <a class="btn btn-secondary ms-3" href="{% url 'dashboard:admin:ticket-list' %}">بازگشت</a>
-          <a class="btn btn-primary ms-3" href="{% url 'dashboard:admin:ticket-delete' pk=ticket.id %}">پایان رسیدگی</a>
+          <a class="btn btn-secondary ms-3" href="{% url 'dashboard:admin:ticket-list' %}">{% trans "Back" %}</a>
+          <a class="btn btn-primary ms-3" href="{% url 'dashboard:admin:ticket-delete' pk=ticket.id %}">{% trans "Close ticket" %}</a>
         </div>
 
       </div>

--- a/core/templates/dashboard/admin/tickets/ticket-list.html
+++ b/core/templates/dashboard/admin/tickets/ticket-list.html
@@ -1,5 +1,6 @@
 {% extends "dashboard/admin/base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
     <!-- Card -->
@@ -7,7 +8,7 @@
         <!-- Header -->
         <div class="card-header border-bottom">
           <div class="d-flex justify-content-between align-items-center">
-            <h5 class="">لیست کاربران</h5>
+            <h5 class="">{% trans "User list" %}</h5>
           </div>
         </div>
         <!-- End Header -->
@@ -19,14 +20,14 @@
 
               <!-- Input Card -->
               <div class="col-md-5 py-1">
-                <input type="text" class="form-control" placeholder="جستجوی" aria-label="جستجوی ایمیل" name="q" id="search-query-filter">
+                <input type="text" class="form-control" placeholder="{% trans 'Search' %}" aria-label="{% trans 'Search email' %}" name="q" id="search-query-filter">
 
               </div>
               <!-- End Input Card -->
               <div class="col-md-3 py-1">
                 <select class="form-select" name="order_by" id="order-by-filter">
-                  <option value="-created_date">جدیدترین</option>
-                  <option value="created_date">قدیمی ترین</option>
+                  <option value="-created_date">{% trans "Newest" %}</option>
+                  <option value="created_date">{% trans "Oldest" %}</option>
                 </select>
               </div>
               <div class="col-md-1 py-1">
@@ -43,12 +44,12 @@
                 <thead class="thead-light">
                   <tr>
                     <th scope="col">#</th>
-                    <th scope="col">نام</th>
-                    <th scope="col">نام خانوادگی</th>
-                    <th scope="col">ایمیل</th>
-                    <th scope="col">شماره تلفن</th>
-                    <th scope="col">موضوع</th>
-                    <th scope="col">ویرایش</th>
+                    <th scope="col">{% trans "First name" %}</th>
+                    <th scope="col">{% trans "Last name" %}</th>
+                    <th scope="col">{% trans "Email" %}</th>
+                    <th scope="col">{% trans "Phone number" %}</th>
+                    <th scope="col">{% trans "Subject" %}</th>
+                    <th scope="col">{% trans "Edit" %}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -94,7 +95,7 @@
               <li class="page-item"><button class="page-link" href="?page={{ page_obj.next_page_number }}" onclick="changePage(`{{page_obj.next_page_number}}`)">{{ page_obj.next_page_number }}</button></li>
               {% endif %}
               {% if page_obj.number|add:'2' < page_obj.paginator.num_pages %}
-              <li class="page-item disabled"><a class="page-link" href="#">...</a></li>
+              <li class="page-item disabled"><a class="page-link" href="#">{% trans "..." %}</a></li>
               {% endif %}
               <li class="page-item"><button class="page-link" href="?page={{page_obj.paginator.num_pages}}" onclick="changePage(`{{page_obj.paginator.num_pages}}`)">{{page_obj.paginator.num_pages}}</button></li>
               <li class="page-item">

--- a/core/templates/dashboard/customer/base.html
+++ b/core/templates/dashboard/customer/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load i18n %}
 <!DOCTYPE html>
 <html lang="fa" dir="rtl">
 
@@ -63,21 +64,21 @@
                     <ul class="navbar-nav">
                         <li class="nav-item">
                             <a class="nav-link  {% if request.resolver_match.view_name  == 'website:home' %} active {% endif %}"
-                                href="{% url 'website:home' %}">صفحه اصلی</a>
+                                href="{% url 'website:home' %}">{% trans "Home" %}</a>
                         </li>
 
 
                         <li class="nav-item">
                             <a class="nav-link {% if request.resolver_match.view_name  == 'shop:product-grid' %} active {% endif %}"
-                                href="{% url 'shop:list_grid' %}">لیست محصولات</a>
+                                href="{% url 'shop:list_grid' %}">{% trans "Product List" %}</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link {% if request.resolver_match.view_name  == 'website:about' %} active {% endif %}"
-                                href="{% url 'website:about' %}">درباره ما</a>
+                                href="{% url 'website:about' %}">{% trans "About Us" %}</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link {% if request.resolver_match.view_name  == 'website:contact' %} active {% endif %}"
-                                href="{% url 'website:contact' %}">ارتباط با ما</a>
+                                href="{% url 'website:contact' %}">{% trans "Contact Us" %}</a>
                         </li>
 
 
@@ -115,12 +116,12 @@
                             </button>
 
                             <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-                                <a class="dropdown-item" href="{% url 'dashboard:check' %}">پروفایل</a>
-                                <a class="dropdown-item" href="{% url 'logout' %}">خروج</a>
+                                <a class="dropdown-item" href="{% url 'dashboard:check' %}">{% trans "Profile" %}</a>
+                                <a class="dropdown-item" href="{% url 'logout' %}">{% trans "Log out" %}</a>
                             </div>
 
                             {% else %}
-                            <a class="btn btn-primary btn-transition" href="{% url 'login' %}">ورود</a>
+                            <a class="btn btn-primary btn-transition" href="{% url 'login' %}">{% trans "Log in" %}</a>
                             {% endif %}
                         </li>
                     </ul>
@@ -142,7 +143,7 @@
                 <div class="row align-items-center">
                     <div class="col">
                         <div class="d-none d-lg-block">
-                            <h1 class="h2 text-white">داشبورد</h1>
+                            <h1 class="h2 text-white">{% trans "Dashboard" %}</h1>
                         </div>
 
                         <!-- Breadcrumb -->
@@ -155,7 +156,7 @@
 
                     <div class="col-auto">
                         <div class="d-none d-lg-block">
-                            <a class="btn btn-soft-light btn-sm" href="{% url 'logout' %}">خروج</a>
+                            <a class="btn btn-soft-light btn-sm" href="{% url 'logout' %}">{% trans "Log out" %}</a>
                         </div>
                         <!-- Responsive Toggle Button -->
                         <button class="navbar-toggler d-lg-none" type="button" data-bs-toggle="collapse"
@@ -209,46 +210,45 @@
                         </a>
                         <!-- End Logo -->
 
-                        <p class="text-muted small mb-0">&copy; Maryam Farajian 2023 Front RTL</p>
+                        <p class="text-muted small mb-0">&copy; {% trans "Maryam Farajian 2023 Front RTL" %}</p>
                     </div>
                 </div>
 
                 <div class="col-6 col-md-4 col-lg-3 ms-lg-auto mb-5 mb-lg-0">
-                    <h5>حساب</h5>
+                    <h5>{% trans "Account" %}</h5>
 
                     <!-- List -->
                     <ul class="list-unstyled list-py-1">
-                        <li><a class="link-sm text-secondary" href="#">سفارش دادن</a></li>
-                        <li><a class="link-sm text-secondary" href="#">گزینه های حمل و نقل</a></li>
-                        <li><a class="link-sm text-secondary" href="#">پیگیری یک بسته</a></li>
-                        <li><a class="link-sm text-secondary" href="#">در دسترس بودن کشور</a></li>
+                        <li><a class="link-sm text-secondary" href="#">{% trans "Place an order" %}</a></li>
+                        <li><a class="link-sm text-secondary" href="#">{% trans "Shipping options" %}</a></li>
+                        <li><a class="link-sm text-secondary" href="#">{% trans "Track a package" %}</a></li>
+                        <li><a class="link-sm text-secondary" href="#">{% trans "Country availability" %}</a></li>
                     </ul>
                     <!-- End List -->
                 </div>
                 <!-- End Col -->
 
                 <div class="col-6 col-md-4 col-lg-3 mb-5 mb-lg-0">
-                    <h5>شرکت</h5>
+                    <h5>{% trans "Company" %}</h5>
 
                     <!-- List -->
                     <ul class="list-unstyled list-py-1">
-                        <li><a class="link-sm text-secondary" href="#">تامین مالی</a></li>
-                        <li><a class="link-sm text-secondary" href="#">بازیافت</a></li>
-                        <li><a class="link-sm text-secondary" href="#">سیاست بازگشت</a></li>
+                        <li><a class="link-sm text-secondary" href="#">{% trans "Financing" %}</a></li>
+                        <li><a class="link-sm text-secondary" href="#">{% trans "Recycling" %}</a></li>
+                        <li><a class="link-sm text-secondary" href="#">{% trans "Return policy" %}</a></li>
                     </ul>
                     <!-- End List -->
                 </div>
                 <!-- End Col -->
 
                 <div class="col-md-4 col-lg-2 mb-5 mb-lg-0">
-                    <h5 class="mb-3">منابع</h5>
+                    <h5 class="mb-3">{% trans "Resources" %}</h5>
 
                     <!-- List -->
                     <ul class="list-unstyled list-py-1">
                         <li><a class="link-sm link-secondary" href="#"><i class="bi-question-circle-fill me-1"></i>
-                                کمک</a></li>
-                        <li><a class="link-sm link-secondary" href="#"><i class="bi-person-circle me-1"></i> حساب
-                                شما</a></li>
+                                {% trans "Help" %}</a></li>
+                        <li><a class="link-sm link-secondary" href="#"><i class="bi-person-circle me-1"></i> {% trans "Your account" %}</a></li>
                     </ul>
                     <!-- End List -->
 
@@ -260,7 +260,7 @@
                                 <img class="avatar avatar-xss avatar-circle ms-2"
                                     src="{% static 'vendor/flag-icon-css/flags/1x1/us.svg' %}" alt="Image description"
                                     width="16" />
-                                <span>انگلیسی (US)</span>
+                                <span>{% trans "English (US)" %}</span>
                             </span>
                         </button>
 
@@ -269,25 +269,25 @@
                                 <img class="avatar avatar-xss avatar-circle ms-2"
                                     src="{% static 'vendor/flag-icon-css/flags/1x1/us.svg' %}" alt="Image description"
                                     width="16" />
-                                <span>انگلیسی</span>
+                                <span>{% trans "English" %}</span>
                             </a>
                             <a class="dropdown-item d-flex align-items-center" href="#">
                                 <img class="avatar avatar-xss avatar-circle ms-2"
                                     src="{% static 'vendor/flag-icon-css/flags/1x1/de.svg' %}" alt="Image description"
                                     width="16" />
-                                <span>آلمانی</span>
+                                <span>{% trans "German" %}</span>
                             </a>
                             <a class="dropdown-item d-flex align-items-center" href="#">
                                 <img class="avatar avatar-xss avatar-circle ms-2"
                                     src="{% static 'vendor/flag-icon-css/flags/1x1/es.svg' %}" alt="Image description"
                                     width="16" />
-                                <span>اسپانیایی</span>
+                                <span>{% trans "Spanish" %}</span>
                             </a>
                             <a class="dropdown-item d-flex align-items-center" href="#">
                                 <img class="avatar avatar-xss avatar-circle ms-2"
                                     src="{% static 'vendor/flag-icon-css/flags/1x1/cn.svg' %}" alt="Image description"
                                     width="16" />
-                                <span>چینی</span>
+                                <span>{% trans "Chinese" %}</span>
                             </a>
                         </div>
                     </div>
@@ -334,13 +334,13 @@
                     <!-- List -->
                     <ul class="list-inline list-separator">
                         <li class="list-inline-item">
-                            <a class="link-sm link-secondary" href="/page-privacy.html">حریم خصوصی و خط مشی</a>
+                            <a class="link-sm link-secondary" href="/page-privacy.html">{% trans "Privacy Policy" %}</a>
                         </li>
                         <li class="list-inline-item">
-                            <a class="link-sm link-secondary" href="/page-terms.html">مقررات و شرایط</a>
+                            <a class="link-sm link-secondary" href="/page-terms.html">{% trans "Terms & Conditions" %}</a>
                         </li>
                         <li class="list-inline-item">
-                            <a class="link-sm link-secondary" href="/#">مشاغل</a>
+                            <a class="link-sm link-secondary" href="/#">{% trans "Careers" %}</a>
                         </li>
                     </ul>
                     <!-- End List -->
@@ -387,10 +387,10 @@
                             <!-- Input Card -->
                             <div class="input-card">
                                 <div class="input-card-form">
-                                    <input type="text" class="form-control form-control-lg" placeholder="جستجو محصولات"
-                                        name="q" aria-label="جستجو محصولات">
+                                    <input type="text" class="form-control form-control-lg" placeholder="{% trans 'Search products' %}"
+                                        name="q" aria-label="{% trans 'Search products' %}">
                                 </div>
-                                <button type="submit" class="btn btn-primary btn-lg">جستجو کردن</button>
+                                <button type="submit" class="btn btn-primary btn-lg">{% trans "Search" %}</button>
                             </div>
                             <!-- End Input Card -->
                         </form>

--- a/core/templates/dashboard/customer/home.html
+++ b/core/templates/dashboard/customer/home.html
@@ -1,22 +1,23 @@
 {% extends 'dashboard/customer/base.html' %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
 <!-- Card -->
 <div class="card">
     <!-- Header -->
     <div class="card-header border-bottom">
-        <h5 class="card-header-title">اطلاعات من</h5>
+        <h5 class="card-header-title">{% trans "My information" %}</h5>
     </div>
     <!-- End Header -->
 
     <div class="container mt-5">
-        <!-- <h1 class="mb-4 text-center">اطلاعات من</h1> -->
+        <!-- <h1 class="mb-4 text-center">My information</h1> -->
         <div class="row">
             <div class="col-md-6 mb-3">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">ایمیل</h5>
+                        <h5 class="card-title">{% trans "Email" %}</h5>
                         <p class="card-text">{{user_info.email}}</p>
                     </div>
                 </div>
@@ -24,7 +25,7 @@
             <div class="col-md-6 mb-3">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">نام و نام خانوادگی</h5>
+                        <h5 class="card-title">{% trans "Full name" %}</h5>
                         <p class="card-text">{{user_info.user_profile.get_fullname}}</p>
                     </div>
                 </div>
@@ -32,7 +33,7 @@
             <div class="col-md-6 mb-3">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">شماره تلفن</h5>
+                        <h5 class="card-title">{% trans "Phone number" %}</h5>
                         <p class="card-text">{{user_info.user_profile.phone_number}}</p>
                     </div>
                 </div>
@@ -40,8 +41,8 @@
             <div class="col-md-6 mb-3">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">نوع کاربر</h5>
-                        <p class="card-text">مشتری</p>
+                        <h5 class="card-title">{% trans "User type" %}</h5>
+                        <p class="card-text">{% trans "Customer" %}</p>
                     </div>
                 </div>
             </div>

--- a/core/templates/dashboard/customer/orders/add-addresses.html
+++ b/core/templates/dashboard/customer/orders/add-addresses.html
@@ -1,10 +1,11 @@
 {% extends "dashboard/customer/base.html" %}
 {% load static %}
+{% load i18n %}
 {% block content %}
           <!-- Card -->
           <div class="card">
             <div class="card-header border-bottom">
-              <h4 class="card-header-title">نشانی</h4>
+              <h4 class="card-header-title">{% trans "Address" %}</h4>
             </div>
 
             <!-- Body -->
@@ -14,7 +15,7 @@
 
                 <!-- Form -->
                 <div class="row mb-4">
-                  <label for="firstNameLabel" class="col-sm-3 col-form-label form-label">استان / شهر</label>
+                  <label for="firstNameLabel" class="col-sm-3 col-form-label form-label">{% trans "State / City" %}</label>
 
                   <div class="col-sm-9">
                     <div class="input-group">
@@ -27,7 +28,7 @@
 
                 <!-- Form -->
                 <div class="js-add-field row mb-4">
-                  <label for="phoneLabel" class="col-sm-3 col-form-label form-label">کد پستی</label>
+                  <label for="phoneLabel" class="col-sm-3 col-form-label form-label">{% trans "Postal code" %}</label>
                   <div class="col-sm-9">
                     <div class="input-group">
                         {{form.zip_code}}
@@ -38,7 +39,7 @@
                 </div>
             </div>
             <div class="row mb-4">
-              <label for="firstNameLabel" class="col-sm-3 col-form-label form-label">آدرس</label>
+              <label for="firstNameLabel" class="col-sm-3 col-form-label form-label">{% trans "Address" %}</label>
 
               <div class="col-sm-9">
                 <div class="input-group">
@@ -50,7 +51,7 @@
             <!-- Footer -->
              <br>
               <div class="d-flex justify-content-end gap-3">
-                <button type="submit" class="btn btn-primary">ذخیره آدرس</button>
+                <button type="submit" class="btn btn-primary">{% trans "Save address" %}</button>
               </div>
             <!-- End Footer -->
               </form>

--- a/core/templates/dashboard/customer/orders/addresses.html
+++ b/core/templates/dashboard/customer/orders/addresses.html
@@ -1,10 +1,11 @@
 {% extends "dashboard/customer/base.html" %}
 {% load static %}
+{% load i18n %}
 {% block content %}
 <div class="card">
     <!-- Header -->
     <div class="card-header border-bottom">
-      <h5 class="card-header-title">آدرس های من</h5>
+      <h5 class="card-header-title">{% trans "My addresses" %}</h5>
     </div>
     <!-- End Header -->
 
@@ -21,8 +22,8 @@
               <span class="d-block mb-2">{{address.zip_code}}</span>
               <span class="d-block mb-2">{{address.address}}</span>
               <a class="btn btn-white btn-xs" href="{% url 'dashboard:customer:change-addresses' pk=address.pk %}">
-                <i class="bi-pencil-fill me-1"></i> آدرس را ویرایش
-                کنید
+                <i class="bi-pencil-fill me-1"></i> {% trans "Edit address" %}
+               
               </a>
             </label>
           </div>
@@ -39,7 +40,7 @@
             <div class="card-body card-dashed-body py-8">
               <img class="avatar avatar-lg avatar-4x3 mb-2" src="{% static 'svg/illustrations/oc-address.svg' %}"
                 alt="Image Description" />
-              <span class="d-block"><i class="bi-plus"></i> یک آدرس جدید اضافه کنید</span>
+              <span class="d-block"><i class="bi-plus"></i> {% trans "Add a new address" %}</span>
             </div>
           </a>
           <!-- End Card -->

--- a/core/templates/dashboard/customer/orders/change-addresses.html
+++ b/core/templates/dashboard/customer/orders/change-addresses.html
@@ -1,10 +1,11 @@
 {% extends "dashboard/customer/base.html" %}
 {% load static %}
+{% load i18n %}
 {% block content %}
           <!-- Card -->
           <div class="card">
             <div class="card-header border-bottom">
-              <h4 class="card-header-title">نشانی</h4>
+              <h4 class="card-header-title">{% trans "Address" %}</h4>
             </div>
 
             <!-- Body -->
@@ -14,7 +15,7 @@
 
                 <!-- Form -->
                 <div class="row mb-4">
-                  <label for="firstNameLabel" class="col-sm-3 col-form-label form-label">استان / شهر</label>
+                  <label for="firstNameLabel" class="col-sm-3 col-form-label form-label">{% trans "State / City" %}</label>
 
                   <div class="col-sm-9">
                     <div class="input-group">
@@ -27,7 +28,7 @@
 
                 <!-- Form -->
                 <div class="js-add-field row mb-4">
-                  <label for="phoneLabel" class="col-sm-3 col-form-label form-label">کد پستی</label>
+                  <label for="phoneLabel" class="col-sm-3 col-form-label form-label">{% trans "Postal code" %}</label>
                   <div class="col-sm-9">
                     <div class="input-group">
                         {{form.zip_code}}
@@ -38,7 +39,7 @@
                 </div>
             </div>
             <div class="row mb-4">
-              <label for="firstNameLabel" class="col-sm-3 col-form-label form-label">آدرس</label>
+              <label for="firstNameLabel" class="col-sm-3 col-form-label form-label">{% trans "Address" %}</label>
 
               <div class="col-sm-9">
                 <div class="input-group">
@@ -50,7 +51,7 @@
             <!-- Footer -->
              <br>
               <div class="d-flex justify-content-end gap-3">
-                <button type="submit" class="btn btn-primary">ویرایش آدرس</button>
+                <button type="submit" class="btn btn-primary">{% trans "Edit address" %}</button>
               </div>
             <!-- End Footer -->
               </form>

--- a/core/templates/dashboard/customer/orders/order-detail.html
+++ b/core/templates/dashboard/customer/orders/order-detail.html
@@ -1,6 +1,7 @@
 {% extends "dashboard/customer/base.html" %}
 {% load static %}
 {% load humanize %}
+{% load i18n %}
 
 {% block content %}
 
@@ -9,9 +10,9 @@
     <!-- Header -->
     <div class="card-header border-bottom">
       <div class="d-flex justify-content-between align-items-center">
-        <h5 class="">شماره سفارش : {{order.id}}</h5>
+        <h5 class="">{% blocktrans with order_id=order.id %}Order number : {{ order_id }}{% endblocktrans %}</h5>
         {% if order.get_status.id == 2 %}
-        <a class="btn btn-primary" href="{% url 'dashboard:customer:order-invoice' pk=order.id %}" target="_blank">مشاهده فاکتور</a>
+        <a class="btn btn-primary" href="{% url 'dashboard:customer:order-invoice' pk=order.id %}" target="_blank">{% trans "View invoice" %}</a>
         {% endif %}
       </div>
     </div>
@@ -27,10 +28,10 @@
             <thead class="thead-light">
               <tr>
                 <th scope="col">#</th>
-                <th scope="col">تصویر</th>
-                <th scope="col">کد محصول</th>
-                <th scope="col">نام محصول</th>
-                <th scope="col">تعداد سفارش</th>
+                <th scope="col">{% trans "Image" %}</th>
+                <th scope="col">{% trans "Product code" %}</th>
+                <th scope="col">{% trans "Product name" %}</th>
+                <th scope="col">{% trans "Quantity ordered" %}</th>
               </tr>
             </thead>
             {% for product in order.order_items.all %}
@@ -44,7 +45,7 @@
                 </td>
                 <td>{{product.product.id}}</td>
                 <td>{{product.product.title}}</td>
-                <td>{{product.quantity}} عدد</td>
+                <td>{% blocktrans count quantity=product.quantity %}{{ quantity }} item{% plural %}{{ quantity }} items{% endblocktrans %}</td>
               </tr>
             </tbody>
             {% endfor %}
@@ -60,32 +61,32 @@
     <div class="card-footer row pt-5 mt-5">
       <form>
         <div class="row mb-3 align-items-center">
-          <dt class="col-md-3">سفارش دهنده:</dt>
+          <dt class="col-md-3">{% trans "Customer:" %}</dt>
           <dl class="col-md-3">{{order.user.user_profile.get_fullname}}</dl>
-          <dt class="col-md-3">وضعیت سفارش:</dt>
+          <dt class="col-md-3">{% trans "Order status:" %}</dt>
           <dl class="col-md-3 ">{{order.get_status.label}}</dl>
         </div>
         <div class="row mb-3">
-          <dt class="col-md-3"> تاریخ سفارش:</dt>
+          <dt class="col-md-3">{% trans "Order date:" %}</dt>
           <dl class="col-md-3">{{order.created_date|date:'Y-m-d h:i'}}</dl>
-          <dt class="col-md-3"> درصد تخفیف:</dt>
+          <dt class="col-md-3">{% trans "Discount percentage:" %}</dt>
           <dl class="col-md-3">{{order.coupon.discount_percent}}</dl>
         </div>
         <!-- End Row -->
         <div class="row mb-3">
-          <dt class="col-md-3"> کد پستی:</dt>
+          <dt class="col-md-3">{% trans "Postal code:" %}</dt>
           <dl class="col-md-3">{{order.address.zip_code}}</dl>
-          <dt class="col-md-3"> قیمت اصلی:</dt>
-          <dl class="col-md-3">{{order.get_totalprice|intcomma}} تومان</dl>
+          <dt class="col-md-3">{% trans "Original price:" %}</dt>
+          <dl class="col-md-3">{{order.get_totalprice|intcomma}} {% trans "Toman" %}</dl>
         </div>
         <div class="row mb-3">
-          <dt class="col-md-3"> آدرس:</dt>
+          <dt class="col-md-3">{% trans "Address:" %}</dt>
           <dl class="col-md-3">{{order.get_fulladdress}}</dl>
-          <dt class="col-md-3"> قیمت با تخفیف:</dt>
-          <dl class="col-md-3">{{order.final_price|intcomma}} تومان</dl>
+          <dt class="col-md-3">{% trans "Discounted price:" %}</dt>
+          <dl class="col-md-3">{{order.final_price|intcomma}} {% trans "Toman" %}</dl>
         </div>
         <div class=" d-flex pt-5 justify-content-end">
-          <a class="btn btn-secondary ms-3" href="{% url 'dashboard:customer:order-list' %}">بازگشت</a>
+          <a class="btn btn-secondary ms-3" href="{% url 'dashboard:customer:order-list' %}">{% trans "Back" %}</a>
         </div>
       </form>
     </div>

--- a/core/templates/dashboard/customer/orders/order-invoice.html
+++ b/core/templates/dashboard/customer/orders/order-invoice.html
@@ -1,8 +1,9 @@
 {% load static %}
 {% load humanize %}
+{% load i18n %}
 
 <!DOCTYPE html>
-<html lang="fa" dir="rtl">
+<html lang="en" dir="rtl">
 
 <head>
   <!-- Required Meta Tags Always Come First -->
@@ -10,7 +11,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
   <!-- Title -->
-  <title>فاکتور</title>
+  <title>{% trans "Invoice" %}</title>
 
   <!-- Font -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
@@ -37,7 +38,7 @@
 
               <div class="col-sm-auto  text-right mb-3">
                 <div class="mb-3">
-                  <h2> فاکتور شماره</h2>
+                  <h2> {% trans "Invoice number" %}</h2>
                   <span class="d-block">#{{order.id}}</span>
                 </div>
 
@@ -49,7 +50,7 @@
                   <img class="avatar" src="{% static 'svg/logos/logo-short.svg' %}" alt="Logo">
                 </div>
 
-                <h1 class="h2 text-primary">Front Inc.</h1>
+                <h1 class="h2 text-primary">{% trans "Front Inc." %}</h1>
               </div>
               <!-- End Col -->
 
@@ -59,11 +60,11 @@
             <div class="row justify-content-md-between mb-3">
               <div class="col-md">
                 <dl class="row">
-                  <dt class="col-sm-8">نام سفارش دهنده:</dt>
+                  <dt class="col-sm-8">{% trans "Customer name:" %}</dt>
                   <dd class="col-sm-4">{{order.user.user_profile.get_fullname}}</dd>
                 </dl>
                 <dl>
-                  <dt class="col-sm-8">آدرس:</dt>
+                  <dt class="col-sm-8">{% trans "Address:" %}</dt>
                   <address>
                     {{order.get_fulladdress}}
                   </address>
@@ -74,9 +75,9 @@
 
               <div class="col-md text-md-end">
                 <dl class="row">
-                  <dt class="col-sm-8">زمان سفارش:</dt>
+                  <dt class="col-sm-8">{% trans "Order date:" %}</dt>
                   <dd class="col-sm-4">{{order.created_date|date:'Y-m-d'}}</dd>
-                  <dt class="col-sm-8">وضعیت سفارش:</dt>
+                  <dt class="col-sm-8">{% trans "Order status:" %}</dt>
                   <dd class="col-sm-4">{{order.get_status.label}}</dd>
                 </dl>
               </div>
@@ -89,9 +90,9 @@
               <table class="table table-borderless table-nowrap table-align-middle">
                 <thead class="thead-light">
                   <tr>
-                    <th>کالا</th>
-                    <th>تعداد</th>
-                    <th class="table-text-end">قیمت</th>
+                    <th>{% trans "Item" %}</th>
+                    <th>{% trans "Quantity" %}</th>
+                    <th class="table-text-end">{% trans "Price" %}</th>
                   </tr>
                 </thead>
 
@@ -101,7 +102,7 @@
                     <th>{{product.product.title}}</th>
                     <td>{{product.quantity}}</td>
 
-                    <td class="table-text-end">{{product.product.offer}} تومان</td>
+                    <td class="table-text-end">{{product.product.offer}} {% trans "Toman" %}</td>
                   </tr>
                   {% endfor %}
                 </tbody>
@@ -114,8 +115,8 @@
             <div class="row mb-3">
 
               <div class="row mb-3">
-                <dt class="col-md-3">قیمت نهایی:</dt>
-                <dl class="col-md-3">{{order.get_totalprice|intcomma}} تومان</dl>
+                <dt class="col-md-3">{% trans "Final price:" %}</dt>
+                <dl class="col-md-3">{{order.get_totalprice|intcomma}} {% trans "Toman" %}</dl>
               </div>
               <!-- End Row -->
 
@@ -130,7 +131,7 @@
         <!-- Footer -->
         <div class="d-flex justify-content-end d-print-none gap-3">
           <a class="btn btn-primary" href="javascript:;" onclick="window.print(); return false;">
-            <i class="bi-printer me-1"></i> Print details
+            <i class="bi-printer me-1"></i> {% trans "Print details" %}
           </a>
         </div>
         <!-- End Footer -->

--- a/core/templates/dashboard/customer/orders/orders.html
+++ b/core/templates/dashboard/customer/orders/orders.html
@@ -1,6 +1,7 @@
 {% extends "dashboard/customer/base.html" %}
 {% load static %}
 {% load humanize %}
+{% load i18n %}
 
 {% block content %}
 
@@ -17,7 +18,13 @@
           <!-- Select Group -->
           <div class="d-sm-flex align-items-sm-center mb-5">
             <div class="mb-2 mb-sm-0 me-3">
-              <strong class="text-dark">{{orders_counter}} سفارش</strong>
+              <strong class="text-dark">
+                {% blocktrans count order_count=orders_counter %}
+                  {{ order_count }} order
+                {% plural %}
+                  {{ order_count }} orders
+                {% endblocktrans %}
+              </strong>
             </div>
           </div>
           <!-- End Select Group -->
@@ -30,25 +37,25 @@
               <div class="card-body">
                 <div class="row">
                   <div class="col-6 col-md mb-3 mb-md-0">
-                    <small class="card-subtitle mb-0">جمع</small>
-                    <small class="text-dark fw-semibold">{{order.final_price|intcomma}} تومان</small>
+                    <small class="card-subtitle mb-0">{% trans "Total" %}</small>
+                    <small class="text-dark fw-semibold">{{order.final_price|intcomma}} {% trans "Toman" %}</small>
                   </div>
                   <!-- End Col -->
 
                   <div class="col-6 col-md mb-3 mb-md-0">
-                    <small class="card-subtitle mb-0">وضعیت </small>
+                    <small class="card-subtitle mb-0">{% trans "Status" %} </small>
                     <small class="text-dark fw-semibold">{{order.get_status.label}}</small>
                   </div>
                   <!-- End Col -->
 
                   <div class="col-6 col-md">
-                    <small class="card-subtitle mb-0">شماره سفارش</small>
+                    <small class="card-subtitle mb-0">{% trans "Order number" %}</small>
                     <small class="text-dark fw-semibold">{{order.id}}</small>
                   </div>
                   <!-- End Col -->
 
                   <div class="col-6 col-md">
-                    <small class="card-subtitle mb-0">زمان سفارش:</small>
+                    <small class="card-subtitle mb-0">{% trans "Order time:" %}</small>
                     <small class="text-dark fw-semibold">{{order.created_date|date:'Y-m-d h:i'}}</small>
                   </div>
                   <!-- End Col -->
@@ -73,10 +80,10 @@
                     <div class="d-grid gap-2">
                       {% if order.get_status.id == 2 %}
                       <a class="btn btn-white btn-sm" href="{% url 'dashboard:customer:order-invoice' pk=order.id %}">
-                        <i class="bi-receipt small me-2"></i> مشاهده فاکتور
+                        <i class="bi-receipt small me-2"></i> {% trans "View invoice" %}
                       </a>
                       {% endif %}
-                      <a class="btn btn-primary btn-sm" href="{% url 'dashboard:customer:order-detail' pk=order.id %}">دیدن سفارش</a>
+                      <a class="btn btn-primary btn-sm" href="{% url 'dashboard:customer:order-detail' pk=order.id %}">{% trans "View order" %}</a>
                     </div>
                   </div>
                 </div>
@@ -111,7 +118,7 @@
               <li class="page-item"><button class="page-link" href="?page={{ page_obj.next_page_number }}" onclick="changePage(`{{page_obj.next_page_number}}`)">{{ page_obj.next_page_number }}</button></li>
               {% endif %}
               {% if page_obj.number|add:'2' < page_obj.paginator.num_pages %}
-              <li class="page-item disabled"><a class="page-link" href="#">...</a></li>
+              <li class="page-item disabled"><a class="page-link" href="#">{% trans "..." %}</a></li>
               {% endif %}
               <li class="page-item"><button class="page-link" href="?page={{page_obj.paginator.num_pages}}" onclick="changePage(`{{page_obj.paginator.num_pages}}`)">{{page_obj.paginator.num_pages}}</button></li>
               <li class="page-item">
@@ -133,8 +140,8 @@
           <div class="text-center content-space-1">
             <img class="avatar avatar-xl mb-3" src="{% static 'svg/illustrations/empty-state-no-data.svg' %}"
               alt="Image Description">
-            <p class="card-text">هیچ داده ای برای نمایش وجود ندارد</p>
-            <a class="btn btn-white btn-sm" href="#">شروع به خرید کنید</a>
+            <p class="card-text">{% trans "There is no data to display" %}</p>
+            <a class="btn btn-white btn-sm" href="#">{% trans "Start shopping" %}</a>
           </div>
           <!-- End Empty State -->
         </div>

--- a/core/templates/dashboard/customer/profile/change-pass.html
+++ b/core/templates/dashboard/customer/profile/change-pass.html
@@ -1,11 +1,12 @@
 {% extends 'dashboard/customer/base.html' %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
 <!-- Card -->
 <div class="card mb-3">
     <div class="card-header border-bottom">
-        <h5 class="card-header-title">رمزعبور</h5>
+        <h5 class="card-header-title">{% trans "Password" %}</h5>
     </div>
 
     <!-- Body -->
@@ -14,47 +15,46 @@
         <form action="." method="post">{% csrf_token %}
             <!-- Form -->
             <div class="row mb-4">
-              <label for="currentPasswordLabel" class="col-sm-3 col-form-label form-label">رمز عبور فعلی</label>
+              <label for="currentPasswordLabel" class="col-sm-3 col-form-label form-label">{% trans "Current password" %}</label>
 
               <div class="col-sm-9">
                 <input type="password" class="form-control" name="old_password" id="currentPasswordLabel"
-                  placeholder="Enter current password" aria-label="Enter current password">
+                  placeholder="{% trans 'Enter current password' %}" aria-label="{% trans 'Enter current password' %}">
               </div>
             </div>
             <!-- End Form -->
 
             <!-- Form -->
             <div class="row mb-4">
-              <label for="newPassword" class="col-sm-3 col-form-label form-label">رمز عبور جدید</label>
+              <label for="newPassword" class="col-sm-3 col-form-label form-label">{% trans "New password" %}</label>
 
               <div class="col-sm-9">
                 <input type="password" class="form-control" name="new_password1" id="newPassword"
-                  placeholder="Enter new password" aria-label="Enter new password">
+                  placeholder="{% trans 'Enter new password' %}" aria-label="{% trans 'Enter new password' %}">
               </div>
             </div>
             <!-- End Form -->
 
             <!-- Form -->
             <div class="row mb-4">
-              <label for="confirmNewPasswordLabel" class="col-sm-3 col-form-label form-label">رمز عبور جدید را
-                تایید کنید</label>
+              <label for="confirmNewPasswordLabel" class="col-sm-3 col-form-label form-label">{% trans "Confirm new password" %}</label>
 
               <div class="col-sm-9">
                 <div class="mb-3">
                   <input type="password" class="form-control" name="new_password2"
-                    id="confirmNewPasswordLabel" placeholder="Confirm your new password"
-                    aria-label="Confirm your new password">
+                    id="confirmNewPasswordLabel" placeholder="{% trans 'Confirm your new password' %}"
+                    aria-label="{% trans 'Confirm your new password' %}">
                 </div>
 
-                <h5>الزامات رمز عبور:</h5>
+                <h5>{% trans "Password requirements:" %}</h5>
 
-                <p class="card-text small">اطمینان حاصل کنید که این الزامات برآورده شده است:</p>
+                <p class="card-text small">{% trans "Make sure these requirements are met:" %}</p>
 
                 <ul class="small">
-                  <li>حداقل 8 کاراکتر - هر چه بیشتر باشد، بهتر است</li>
-                  <li>حداقل یک نویسه کوچک</li>
-                  <li>حداقل یک کاراکتر بزرگ</li>
-                  <li>حداقل یک عدد، نماد یا نویسه فضای خالی</li>
+                  <li>{% trans "Minimum 8 characters – the more, the better" %}</li>
+                  <li>{% trans "At least one lowercase character" %}</li>
+                  <li>{% trans "At least one uppercase character" %}</li>
+                  <li>{% trans "At least one number, symbol, or whitespace character" %}</li>
                 </ul>
               </div>
             </div>
@@ -62,7 +62,7 @@
 
 
             <div class="d-flex justify-content-end gap-3">
-                <button type="submit" class="btn btn-primary">بروزرسانی</button>
+                <button type="submit" class="btn btn-primary">{% trans "Update" %}</button>
             </div>
         </form>
         <!-- End Form -->
@@ -74,13 +74,12 @@
 <!-- Card -->
 <div class="card mb-3">
     <div class="card-header border-bottom">
-        <h5 class="card-header-title">حساب های متصل</h5>
+        <h5 class="card-header-title">{% trans "Connected accounts" %}</h5>
     </div>
 
     <!-- Body -->
     <div class="card-body">
-        <p class="card-text">ویژگی‌های یکپارچه این حساب‌ها، همکاری با افرادی را که در Front می‌شناسید آسان‌تر
-            می‌کند.</p>
+        <p class="card-text">{% trans "The integrated features of these accounts make it easier to collaborate with the people you know in Front." %}</p>
 
         <!-- Form -->
         <form>
@@ -97,8 +96,8 @@
                         <div class="flex-grow-1 me-3">
                             <div class="row align-items-center">
                                 <div class="col ">
-                                    <h6 class="mb-1 ">گوگل</h6>
-                                    <span class="d-block small text-body">تقویم و مخاطبین</span>
+                                    <h6 class="mb-1 ">{% trans "Google" %}</h6>
+                                    <span class="d-block small text-body">{% trans "Calendar and contacts" %}</span>
                                 </div>
                                 <!-- End Col -->
 

--- a/core/templates/dashboard/customer/profile/profile.html
+++ b/core/templates/dashboard/customer/profile/profile.html
@@ -1,10 +1,11 @@
 {% extends "dashboard/customer/base.html" %}
 {% load static %}
+{% load i18n %}
 {% block content %}
           <!-- Card -->
           <div class="card">
             <div class="card-header border-bottom">
-              <h4 class="card-header-title">اطلاعات پایه</h4>
+              <h4 class="card-header-title">{% trans "Basic information" %}</h4>
             </div>
 
             <!-- Body -->
@@ -14,7 +15,7 @@
 
                 <!-- Form -->
                 <div class="row mb-4">
-                  <label for="firstNameLabel" class="col-sm-3 col-form-label form-label">نام و نام خانوادگی </label>
+                  <label for="firstNameLabel" class="col-sm-3 col-form-label form-label">{% trans "Full name" %} </label>
 
                   <div class="col-sm-9">
                     <div class="input-group">
@@ -31,8 +32,8 @@
                         "container": "#addPhoneFieldContainer",
                         "defaultCreated": 0
                       }'>
-                  <label for="phoneLabel" class="col-sm-3 col-form-label form-label">تلفن <span
-                      class="form-label-secondary">(اختیاری)</span></label>
+                  <label for="phoneLabel" class="col-sm-3 col-form-label form-label">{% trans "Phone" %} <span
+                      class="form-label-secondary">{% trans "(Optional)" %}</span></label>
 
                   <div class="col-sm-9">
                     <div class="input-group">
@@ -46,7 +47,7 @@
             <!-- End Form -->
             <!-- Footer -->
               <div class="d-flex justify-content-end gap-3">
-                <button type="submit" class="btn btn-primary">ذخیره تغییرات</button>
+                <button type="submit" class="btn btn-primary">{% trans "Save changes" %}</button>
               </div>
             <!-- End Footer -->
               </form>

--- a/core/templates/dashboard/customer/sidebar.html
+++ b/core/templates/dashboard/customer/sidebar.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load i18n %}
 <!-- Navbar -->
  <div class="navbar-expand-lg navbar-light">
     <div id="sidebarNav" class="collapse navbar-collapse navbar-vertical">
@@ -18,53 +19,53 @@
               <h4 class="card-title mb-0">{{request.user.user_profile.get_fullname}}</h4>
               <p class="card-text small">{{request.user.email}}</p>
               <br>
-              <button type="submit" class="btn btn-primary">ذخیره پروفایل</button>
+              <button type="submit" class="btn btn-primary">{% trans "Save profile" %}</button>
             </form>
           </div>
           <!-- End Avatar -->
 
           <!-- Nav -->
-          <span class="text-cap">حساب</span>
+          <span class="text-cap">{% trans "Account" %}</span>
 
           <!-- List -->
           <ul class="nav nav-sm nav-tabs nav-vertical mb-4">
             <li class="nav-item">
               <a class="nav-link" href="{% url 'dashboard:customer:home' %}">
-                <i class="bi-person-badge nav-icon"></i>داشبورد
+                <i class="bi-person-badge nav-icon"></i> {% trans "Dashboard" %}
               </a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="{% url 'dashboard:customer:change-pass' %}">
-                <i class="bi-shield-shaded nav-icon"></i> امنیت
+                <i class="bi-shield-shaded nav-icon"></i> {% trans "Security" %}
               </a>
             </li>
 
             <li class="nav-item">
               <a class="nav-link" href="{% url 'dashboard:customer:profile' %}">
-                <i class="bi-sliders nav-icon"></i> تنظیمات پروفایل
+                <i class="bi-sliders nav-icon"></i> {% trans "Profile settings" %}
               </a>
             </li>
           </ul>
           <!-- End List -->
 
-          <span class="text-cap">خريد كردن</span>
+          <span class="text-cap">{% trans "Shopping" %}</span>
 
           <!-- List -->
           <ul class="nav nav-sm nav-tabs nav-vertical mb-4">
             <li class="nav-item">
               <a class="nav-link " href="{% url 'dashboard:customer:order-list' %}">
-                <i class="bi-basket nav-icon"></i> سفارشات شما
+                <i class="bi-basket nav-icon"></i> {% trans "Your orders" %}
               </a>
             </li>
             <li class="nav-item">
               <a class="nav-link " href="{% url 'dashboard:customer:wishlist' %}">
-                <i class="bi-heart nav-icon"></i>لیست علایق
+                <i class="bi-heart nav-icon"></i> {% trans "Wishlist" %}
               </a>
             </li>
 
             <li class="nav-item">
               <a class="nav-link " href="{% url 'dashboard:customer:addresses' %}">
-                <i class="bi-geo-alt nav-icon"></i> نشانی
+                <i class="bi-geo-alt nav-icon"></i> {% trans "Addresses" %}
               </a>
             </li>
 
@@ -81,7 +82,7 @@
             <ul class="nav nav-sm nav-tabs nav-vertical">
               <li class="nav-item">
                 <a class="nav-link" href="#">
-                  <i class="bi-box-arrow-right nav-icon"></i> خروج
+                  <i class="bi-box-arrow-right nav-icon"></i> {% trans "Log out" %}
                 </a>
               </li>
             </ul>

--- a/core/templates/dashboard/customer/wishlist/wishlist.html
+++ b/core/templates/dashboard/customer/wishlist/wishlist.html
@@ -1,11 +1,18 @@
 {% extends 'dashboard/customer/base.html' %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
 <div class="card">
     <div class="card-header d-sm-flex justify-content-sm-between align-items-sm-center border-bottom">
-      <h5 class="card-header-title">لیست علاقه مندی ها</h5>
-      <span>{{ wish_number }} مورد</span>
+      <h5 class="card-header-title">{% trans "Wishlist" %}</h5>
+      <span>
+        {% blocktrans count wish_count=wish_number %}
+          {{ wish_count }} item
+        {% plural %}
+          {{ wish_count }} items
+        {% endblocktrans %}
+      </span>
     </div>
 
     <!-- Body -->
@@ -30,12 +37,12 @@
                   <div class="d-grid gap-1">
 
                     <div class="text-body">
-                        <span class="small">دسته بندی:</span>
+                        <span class="small">{% trans "Category:" %}</span>
                         <span class="fw-semibold small">
                             {% for cat in wish.product.category.all %}
                             <a class="link-sm link-secondary" href="#">{{cat}}</a>
                             {% if not forloop.last %}
-                            ،
+                            ,
                             {% endif %}
                             {% endfor %}
                         </span>
@@ -50,7 +57,7 @@
                     <form action="{% url 'dashboard:customer:delete-wish' pk=wish.pk %}" method="post">
                         {% csrf_token %}
                         <button class="btn btn-outline-danger btn-sm"  type="submit">
-                            <i class="bi-trash me-1"></i> حذف
+                            <i class="bi-trash me-1"></i> {% trans "Remove" %}
                         </button>
                     </form>
                     </div>
@@ -93,7 +100,7 @@
         <li class="page-item"><button class="page-link" href="?page={{ page_obj.next_page_number }}" onclick="changePage(`{{page_obj.next_page_number}}`)">{{ page_obj.next_page_number }}</button></li>
         {% endif %}
         {% if page_obj.number|add:'2' < page_obj.paginator.num_pages %}
-        <li class="page-item disabled"><a class="page-link" href="#">...</a></li>
+        <li class="page-item disabled"><a class="page-link" href="#">{% trans "..." %}</a></li>
         {% endif %}
         <li class="page-item"><button class="page-link" href="?page={{page_obj.paginator.num_pages}}" onclick="changePage(`{{page_obj.paginator.num_pages}}`)">{{page_obj.paginator.num_pages}}</button></li>
         <li class="page-item">
@@ -108,6 +115,6 @@
     </nav>
     <!-- End Pagination -->
 
-    <a class="card-footer card-link text-center border-top" href="{% url 'shop:list_grid' %}">به خرید ادامه دهید</a>
+    <a class="card-footer card-link text-center border-top" href="{% url 'shop:list_grid' %}">{% trans "Continue shopping" %}</a>
   </div>
 {% endblock content %}


### PR DESCRIPTION
## Summary
- add i18n loading and translation tags to cart templates for counts, labels, and actions
- wrap admin dashboard navigation and management templates with Django translation helpers
- localize customer dashboard, order, profile, and wishlist templates to use translation tags

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e439e7d5e48320802a85880874f7be