### PR TITLE
Translate storefront templates to English and add i18n

### DIFF
--- a/core/templates/includes/latest_prod.html
+++ b/core/templates/includes/latest_prod.html
@@ -1,11 +1,12 @@
 {% load static %}
 {% load humanize %}
+{% load i18n %}
 
 <!-- Card Grid -->
 <div class="container content-space-2 content-space-lg-3">
     <!-- Title -->
     <div class="w-md-75 w-lg-50 text-center mx-md-auto mb-5 mb-md-9">
-      <h2>محصولات اخیر</h2>
+      <h2>{% trans "Latest products" %}</h2>
     </div>
     <!-- End Title -->
   
@@ -19,13 +20,13 @@
             <img class="card-img-top" src="http://127.0.0.1:9000/media/{{ latest_product.product_image_related.all.first.image }}" alt="Image Description">
             {% if latest_product.stock == 0 %}
             <div class="card-pinned-top-start">
-              <span class="badge bg-danger rounded-pill">اتمام موجودی</span>
+              <span class="badge bg-danger rounded-pill">{% trans "Out of stock" %}</span>
             </div>
             {% endif %}
             {% if request.user.is_authenticated %}
             <div class="card-pinned-top-end">
-              <button type="button" class="btn btn-outline-danger btn-xs btn-icon rounded-circle {% if latest_product.id in is_wished %}active{% endif %}" 
-              data-bs-toggle="tooltip" data-bs-placement="top" title="افزودن به علایق" onclick="modify_wish(this,`{{latest_product.id}}`)">
+              <button type="button" class="btn btn-outline-danger btn-xs btn-icon rounded-circle {% if latest_product.id in is_wished %}active{% endif %}"
+              data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Add to wishlist' %}" onclick="modify_wish(this,`{{latest_product.id}}`)">
                 <i class="bi-heart"></i>
               </button>
             </div>
@@ -37,7 +38,7 @@
               {% for cat in latest_product.category.all %}
               <a class="link-sm link-secondary" href="#">{{cat}}</a>
               {% if not forloop.last %}
-                ،
+                ,
               {% endif %}
               {% endfor %}
             </div>
@@ -46,9 +47,9 @@
               <a class="text-dark" href="{% url 'shop:detail' slug=latest_product.slug %}">{{latest_product.title}}</a>
             </h4>
             {% if latest_product.discount_percent %}
-            <p class="card-text text-dark">{{latest_product.offer|intcomma}} <span class="text-body ms-1"><del>{{latest_product.price|intcomma}} تومان</del></span></p>
+            <p class="card-text text-dark">{{latest_product.offer|intcomma}} {% trans "Toman" %} <span class="text-body ms-1"><del>{{latest_product.price|intcomma}} {% trans "Toman" %}</del></span></p>
             {% else %}
-            <p class="card-text text-dark">{{latest_product.price|intcomma}} تومان</p>
+            <p class="card-text text-dark">{{latest_product.price|intcomma}} {% trans "Toman" %}</p>
             {% endif %}
           </div>
 
@@ -68,9 +69,9 @@
             <!-- End Rating -->
 
             {% if not latest_product.stock %}
-                   <button type="button" class="btn btn-outline-primary btn-sm btn-transition rounded-pill">موجود شد بهم اطلاع بده</button>
+                   <button type="button" class="btn btn-outline-primary btn-sm btn-transition rounded-pill">{% trans "Notify me when available" %}</button>
                    {% else %}
-                   <button type="button" class="btn btn-outline-primary btn-sm btn-transition rounded-pill" onclick="addProd(`{{latest_product.id}}`)">افزودن به سبد خرید</button>
+                   <button type="button" class="btn btn-outline-primary btn-sm btn-transition rounded-pill" onclick="addProd(`{{latest_product.id}}`)">{% trans "Add to cart" %}</button>
                    {% endif %}
           </div>
         </div>
@@ -82,7 +83,7 @@
   
     <div class="text-center">
       <a class="btn btn-outline-primary btn-transition rounded-pill" href="{% url 'shop:list_grid' %}"
-        >مشاهده تمامی محصولات</a
+        >{% trans "View all products" %}</a
       >
     </div>
   </div>

--- a/core/templates/includes/popular_product.html
+++ b/core/templates/includes/popular_product.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load humanize %}
+{% load i18n %}
 
 <div class="col-sm-6 col-md-4 mb-4">
     <!-- Card -->
@@ -30,11 +31,11 @@
 
       <div class="card-footer text-center">
         <h3 class="card-title">{{category}}</h3>
-        <p class="card-text text-muted small">شروع از {{min_price|intcomma}} تومان</p>
+        <p class="card-text text-muted small">{% blocktrans with price=min_price|intcomma %}Starting at {{ price }} Toman{% endblocktrans %}</p>
         <a
           class="btn btn-outline-primary btn-sm btn-transition rounded-pill px-6"
           href="/shop/product/list/grid/?q=&category_id={{products.0.category.first.id}}"
-          >مشاهده همه</a
+          >{% trans "View all" %}</a
         >
       </div>
     </div>

--- a/core/templates/includes/similar_prod.html
+++ b/core/templates/includes/similar_prod.html
@@ -1,11 +1,12 @@
 {% load static %}
 {% load humanize %}
+{% load i18n %}
 
     <!-- Card Grid -->
     <div class="container content-space-2 content-space-lg-3">
         <!-- Title -->
         <div class="w-md-75 w-lg-50 text-center mx-md-auto mb-5 mb-md-9">
-          <h2>فقط برای شما</h2>
+          <h2>{% trans "Just for you" %}</h2>
         </div>
         <!-- End Title -->
   
@@ -18,14 +19,14 @@
                   <img class="card-img-top" src="http://127.0.0.1:9000/media/{{ similar_prod.product_image_related.all.first.image }}" alt="Image Description">
                   {% if similar_prod.stock == 0 %}
                   <div class="card-pinned-top-start">
-                    <span class="badge bg-danger rounded-pill">اتمام موجودی</span>
+                    <span class="badge bg-danger rounded-pill">{% trans "Out of stock" %}</span>
                   </div>
                   {% endif %}
 
                   {% if request.user.is_authenticated %}
                   <div class="card-pinned-top-end">
                     <button type="button" class="btn btn-outline-danger btn-xs btn-icon rounded-circle {% if similar_prod.id in is_wished %}active{% endif %}" 
-                    data-bs-toggle="tooltip" data-bs-placement="top" title="افزودن به علایق" onclick="modify_wish(this,`{{similar_prod.id}}`)">
+                    data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Add to wishlist' %}" onclick="modify_wish(this,`{{similar_prod.id}}`)">
                       <i class="bi-heart"></i>
                     </button>
                   </div>
@@ -37,7 +38,7 @@
                     {% for cat in similar_prod.category.all %}
                     <a class="link-sm link-secondary" href="#">{{cat}}</a>
                     {% if not forloop.last %}
-                      ،
+                      ,
                     {% endif %}
                     {% endfor %}
                   </div>
@@ -46,9 +47,9 @@
                     <a class="text-dark" href="{% url 'shop:detail' slug=similar_prod.slug %}">{{similar_prod.title}}</a>
                   </h4>
                   {% if similar_prod.discount_percent %}
-                  <p class="card-text text-dark">{{similar_prod.offer|intcomma}} <span class="text-body ms-1"><del>{{similar_prod.price|intcomma}} تومان</del></span></p>
+                  <p class="card-text text-dark">{{similar_prod.offer|intcomma}} {% trans "Toman" %} <span class="text-body ms-1"><del>{{similar_prod.price|intcomma}} {% trans "Toman" %}</del></span></p>
                   {% else %}
-                  <p class="card-text text-dark">{{similar_prod.price|intcomma}} تومان</p>
+                  <p class="card-text text-dark">{{similar_prod.price|intcomma}} {% trans "Toman" %}</p>
                   {% endif %}
                 </div>
 
@@ -67,7 +68,7 @@
                   </div>
                   <!-- End Rating -->
 
-                  <button type="button" class="btn btn-outline-primary btn-sm btn-transition rounded-pill">افزودن به سبد خرید</button>
+                  <button type="button" class="btn btn-outline-primary btn-sm btn-transition rounded-pill">{% trans "Add to cart" %}</button>
                 </div>
               </div>
               <!-- End Card -->

--- a/core/templates/order/checkout.html
+++ b/core/templates/order/checkout.html
@@ -1,12 +1,13 @@
 {% extends "base.html" %}
 {% load static %}
 {% load humanize %}
+{% load i18n %}
 {% block content %}
     <!-- Content -->
     <div class="container content-space-1 content-space-lg-2">
         <div class="row">
           <div class="col-lg-8 mb-7 mb-lg-0">
-            <h4 class="mb-3">انتخاب آدرس</h4>
+            <h4 class="mb-3">{% trans "Select address" %}</h4>
              <!-- Form -->
           <form action="." method="post" id="checkout">
             {% csrf_token %}
@@ -23,7 +24,7 @@
                 <!-- End Check -->
                 {% endfor %}
                 <div>
-                  <a href="{% url 'dashboard:customer:addresses' %}">مدیریت آدرس ها</a>
+                  <a href="{% url 'dashboard:customer:addresses' %}">{% trans "Manage addresses" %}</a>
                 </div>
               </div>
   
@@ -35,7 +36,7 @@
   
                 <div class="col-sm text-center text-sm-start">
                   <a class="link" href="{% url 'cart:cart-summery' %}">
-                    <i class="bi-chevron-left small ms-1"></i> بازگشت به سبد خرید
+                    <i class="bi-chevron-left small ms-1"></i> {% trans "Back to cart" %}
                   </a>
                 </div>
                 <!-- End Col -->
@@ -52,12 +53,12 @@
               <div class="card card-sm shadow-sm mb-4">
                 <div class="card-body">
                   <div class="border-bottom pb-4 mb-4">
-                    <h3 class="card-header-title">خلاصه سفارش</h3>
+                    <h3 class="card-header-title">{% trans "Order summary" %}</h3>
                   </div>
                     <div class="input-group border-bottom pb-4 mb-3 ">
-                      <input form="checkout" type="text" class="form-control text-center" name="coupon_code" placeholder="کد تخفیف"
-                      aria-label="کد تخفیف" id="coupon-check">
-                      <button class="btn btn-primary" type="button" onclick="validateCoupon()"> بررسی</button>
+                      <input form="checkout" type="text" class="form-control text-center" name="coupon_code" placeholder="{% trans "Discount code" %}"
+                      aria-label="{% trans "Discount code" %}" id="coupon-check">
+                      <button class="btn btn-primary" type="button" onclick="validateCoupon()"> {% trans "Validate" %}</button>
                     </div>
   
                     <div class="border-bottom pb-4 mb-4">
@@ -67,26 +68,26 @@
                       <!-- End Row -->
   
                       <dl class="row">
-                        <dt class="col-sm-6">محاسبه قیمت</dt>
+                        <dt class="col-sm-6">{% trans "Price calculation" %}</dt>
                         <dd class="col-sm-10 text-sm-end mb-0" id="priceDetails">
-                          <span>قیمت کل : {{total_price|intcomma}} تومان</span>
+                          <span>{% blocktrans %}Total price: {{ total_price|intcomma }} Toman{% endblocktrans %}</span>
                           <br>
-                          <span>9% مالیات : {{tax_price|intcomma}} تومان</span>
+                          <span>{% blocktrans %}9% tax: {{ tax_price|intcomma }} Toman{% endblocktrans %}</span>
                           <br>
                         </dd>
                       </dl>
                       <!-- End Row -->
                       <dl class="row">
-                        <dt class="col-sm-6">جمع کل</dt>
+                        <dt class="col-sm-6">{% trans "Grand total" %}</dt>
                         <dd class="col-sm-10 text-sm-end mb-0">
-                          <span id="final-price">{{final_price|intcomma}}</span> تومان
+                          <span id="final-price">{{final_price|intcomma}}</span> {% trans "Toman" %}
                         </dd>
                       </dl>
                       <!-- End Row -->
                     </div>
   
                     <div class="d-grid">
-                      <button form="checkout" type="submit" class="btn btn-primary btn-lg">ثبت نهایی</button>
+                      <button form="checkout" type="submit" class="btn btn-primary btn-lg">{% trans "Submit order" %}</button>
                     </div>
                 </div>
                 <!-- End Card -->
@@ -108,8 +109,8 @@
                   </div>
                 </div>
                 <div class="flex-grow-1 ms-2">
-                  <span class="small me-1">نیاز به پشتیبانی دارید؟</span>
-                  <a class="link small" href="#">ارسال تیکت</a>
+                  <span class="small me-1">{% trans "Need support?" %}</span>
+                  <a class="link small" href="#">{% trans "Submit a ticket" %}</a>
                 </div>
               </div>
               <!-- End Media -->
@@ -126,7 +127,7 @@
 <script>
   function discountPrice(discounted_price){
       // Create a new <span> element with jQuery
-      var discountSpan = $('<span>').text('مقدار تخفیف : ' + discounted_price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + ' تومان');
+      var discountSpan = $('<span>').text('{{ _("Discount amount:") }} ' + discounted_price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + ' {{ _("Toman") }}');
 
       // Find the target <dd> element
       var priceDetails = $('#priceDetails');

--- a/core/templates/order/complete.html
+++ b/core/templates/order/complete.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
       <!-- Content -->
@@ -10,11 +11,11 @@
           </div>
   
           <div class="mb-5">
-            <h1 class="h2">سفارش شما تکمیل شد!</h1>
-            <p>از سفارش شما متشکریم! سفارش شما در حال پردازش است و ظرف 3 تا 6 ساعت تکمیل خواهد شد. پس از تکمیل سفارش شما یک ایمیل تاییدیه دریافت خواهید کرد.</p>
+            <h1 class="h2">{% trans "Your order is complete!" %}</h1>
+            <p>{% trans "Thank you for your order! Your order is being processed and will be completed within 3 to 6 hours. You will receive a confirmation email once it is finished." %}</p>
           </div>
-  
-          <a class="btn btn-primary btn-transition rounded-pill px-6" href="{% url 'shop:list_grid' %}">به خرید ادامه دهید</a>
+
+          <a class="btn btn-primary btn-transition rounded-pill px-6" href="{% url 'shop:list_grid' %}">{% trans "Continue shopping" %}</a>
         </div>
       </div>
       <!-- End Content -->

--- a/core/templates/order/faild.html
+++ b/core/templates/order/faild.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
       <!-- Content -->
@@ -10,10 +11,10 @@
           </div>
   
           <div class="mb-5">
-            <h1 class="h2">پرداخت موفق نبود!</h1>
+            <h1 class="h2">{% trans "Payment was unsuccessful!" %}</h1>
           </div>
-  
-          <a class="btn btn-primary btn-transition rounded-pill px-6" href="{% url 'shop:list_grid' %}">به خرید ادامه دهید</a>
+
+          <a class="btn btn-primary btn-transition rounded-pill px-6" href="{% url 'shop:list_grid' %}">{% trans "Continue shopping" %}</a>
         </div>
       </div>
       <!-- End Content -->

--- a/core/templates/shop/product_detail.html
+++ b/core/templates/shop/product_detail.html
@@ -1,4 +1,9 @@
-{% extends "base.html" %} {% load static %} {% load humanize %} {% load shop_tags %} {% block content %}
+{% extends "base.html" %}
+{% load static %}
+{% load humanize %}
+{% load shop_tags %}
+{% load i18n %}
+{% block content %}
 <!-- Hero -->
 <div class="container content-space-t-1 content-space-t-sm-1">
   <div class="row">
@@ -72,13 +77,13 @@
 
       <!-- Price -->
       <div class="mb-5">
-        <span class="d-block mb-2">قیمت کل:</span>
+        <span class="d-block mb-2">{% trans "Total price:" %}</span>
         <div class="d-flex align-items-center">
           {% if object.discount_pecent %}
-          <h3 class="mb-0">{{object.offer|intcomma}}</h3>
-          <span class="ms-2"><del>{{object.price|intcomma}}</del></span>
+          <h3 class="mb-0">{{object.offer|intcomma}} {% trans "Toman" %}</h3>
+          <span class="ms-2"><del>{{object.price|intcomma}} {% trans "Toman" %}</del></span>
           {% else %}
-          <h3 class="mb-0">{{object.price|intcomma}} تومان</h3>
+          <h3 class="mb-0">{{object.price|intcomma}} {% trans "Toman" %}</h3>
           {% endif %}
         </div>
       </div>
@@ -121,7 +126,7 @@
                   </svg>
                 </span>
               </div>
-              <div class="flex-grow-1 ms-3">ارسال رایگان</div>
+              <div class="flex-grow-1 ms-3">{% trans "Free shipping" %}</div>
             </div>
           </a>
 
@@ -132,8 +137,7 @@
           >
             <div class="accordion-body">
               <p class="mb-0">
-                ما ارسال رایگان را در هر نقطه از ایالات متحده ارائه می دهیم، یک
-                تیم ماهر تحویل جعبه ها را به دفتر شما می آورد.
+                {% trans "We offer free shipping anywhere in the United States, and a skilled team delivers the boxes to your office." %}
               </p>
             </div>
           </div>
@@ -179,7 +183,7 @@
                   </svg>
                 </span>
               </div>
-              <div class="flex-grow-1 ms-3">30 روز بازگشت</div>
+              <div class="flex-grow-1 ms-3">{% trans "30-day return" %}</div>
             </div>
           </a>
 
@@ -190,8 +194,7 @@
           >
             <div class="accordion-body">
               <p class="mb-0">
-                اگر راضی نیستید، آن را برای بازپرداخت کامل بازگردانید. ما از
-                جداسازی قطعات و حمل و نقل برگشت مراقبت خواهیم کرد.
+                {% trans "If you are not satisfied, return it for a full refund. We will take care of disassembly and return shipping." %}
               </p>
             </div>
           </div>
@@ -207,11 +210,11 @@
           class="btn btn-primary btntransition"
           onclick="addProd(`{{object.id}}`)"
         >
-          افزودن به سبد خرید
+          {% trans "Add to cart" %}
         </button>
         {% else %}
         <button type="button" class="btn btn-primary btntransition">
-          موجود شد بهم اطلاع بده
+          {% trans "Notify me when available" %}
         </button>
         {% endif %}
       </div>
@@ -244,8 +247,8 @@
           </div>
         </div>
         <div class="flex-grow-1 ms-2">
-          <span class="small me-1">نیاز به پشتیبانی دارید؟</span>
-          <a class="link small" href="#">ارسال تیکت</a>
+          <span class="small me-1">{% trans "Need support?" %}</span>
+          <a class="link small" href="#">{% trans "Submit a ticket" %}</a>
         </div>
       </div>
       <!-- End Media -->
@@ -288,7 +291,7 @@
                     {% endfor %}
                   </div>
                   <!-- End Rating -->
-                  <span class="text-white">{{reviews.count}} نظر</span>
+                  <span class="text-white">{% blocktrans count review_count=reviews.count %}{{ review_count }} review{% plural %}{{ review_count }} reviews{% endblocktrans %}</span>
                 </div>
               </div>
             </div>
@@ -297,13 +300,13 @@
         </div>
         <!-- End Card -->
 
-        <h3>تجزیه رتبه</h3>
+        <h3>{% trans "Rating breakdown" %}</h3>
 
         <!-- Ratings -->
         <div class="d-grid gap-1">
           <a class="row align-items-center" href="#" style="max-width: 25rem">
             <div class="col-3">
-              <span class="text-dark">5 ستاره</span>
+              <span class="text-dark">{% trans "5 stars" %}</span>
             </div>
             <!-- End Col -->
 
@@ -330,7 +333,7 @@
 
           <a class="row align-items-center" href="#" style="max-width: 25rem">
             <div class="col-3">
-              <span class="text-dark">4 ستاره</span>
+              <span class="text-dark">{% trans "4 stars" %}</span>
             </div>
             <!-- End Col -->
 
@@ -357,7 +360,7 @@
 
           <a class="row align-items-center" href="#" style="max-width: 25rem">
             <div class="col-3">
-              <span class="text-dark">3 ستاره</span>
+              <span class="text-dark">{% trans "3 stars" %}</span>
             </div>
             <!-- End Col -->
 
@@ -384,7 +387,7 @@
 
           <a class="row align-items-center" href="#" style="max-width: 25rem">
             <div class="col-3">
-              <span class="text-dark">2 ستاره</span>
+              <span class="text-dark">{% trans "2 stars" %}</span>
             </div>
             <!-- End Col -->
 
@@ -411,7 +414,7 @@
 
           <a class="row align-items-center" href="#" style="max-width: 25rem">
             <div class="col-3">
-              <span class="text-dark">1 ستاره</span>
+              <span class="text-dark">{% trans "1 star" %}</span>
             </div>
             <!-- End Col -->
 
@@ -440,7 +443,7 @@
       </div>
 
       <h4 class="display-4 text-primary">77%</h4>
-      <p class="small">مشتریان این محصول را توصیه می کنند</p>
+      <p class="small">{% trans "Customers recommend this product" %}</p>
     </div>
     <!-- End Col -->
 
@@ -450,13 +453,13 @@
                   <div class="border-bottom pb-4 mb-4">
                       <div class="row align-items-center">
                           <div class="col-sm mb-2 mb-sm-0">
-                              <h4 class="mb-0">دیدگاه ها</h4>
+                              <h4 class="mb-0">{% trans "Reviews" %}</h4>
                           </div>
   
                           <div class="col-sm-auto mb-2 text-center">
                               <button type="button" class="btn btn-primary btn-transition rounded-pill"
                                   data-bs-toggle="modal" data-bs-target="#submitReviewModal">
-                                  ثبت دیدگاه</button>
+                                  {% trans "Submit review" %}</button>
                           </div>
                           <!-- End Col -->
                       </div>
@@ -507,20 +510,20 @@
             </div>
 
             <div class="mb-2">
-              <span class="text-dark fw-semibold">کریستینا</span>
-              <span>- خرید تایید شده</span>
+              <span class="text-dark fw-semibold">{% trans "Christina" %}</span>
+              <span>- {% trans "Verified purchase" %}</span>
             </div>
 
             <!-- Media -->
             <div class="d-flex align-items-center">
-              <span class="small me-2">آیا این مفید بود؟</span>
+              <span class="small me-2">{% trans "Was this helpful?" %}</span>
 
               <div class="d-flex gap-2">
                 <a class="btn btn-white btn-xs" href="javascript:;">
-                  <i class="bi-hand-thumbs-up me-1"></i> Yes <span>(45)</span>
+                  <i class="bi-hand-thumbs-up me-1"></i> {% trans "Yes" %} <span>(45)</span>
                 </a>
                 <a class="btn btn-white btn-xs" href="javascript:;">
-                  <i class="bi-hand-thumbs-down me-1"></i> نه <span>(21)</span>
+                  <i class="bi-hand-thumbs-down me-1"></i> {% trans "No" %} <span>(21)</span>
                 </a>
               </div>
             </div>
@@ -545,8 +548,8 @@
       <div class="row justify-content-lg-between">
         <!-- Heading -->
         <div class="mb-5">
-          <span class="text-cap">ثبت نام</span>
-          <h2>اخبار جدید را دریافت کنید</h2>
+          <span class="text-cap">{% trans "Sign up" %}</span>
+          <h2>{% trans "Get the latest news" %}</h2>
         </div>
         <!-- End Heading -->
 
@@ -555,26 +558,25 @@
           <div class="input-card input-card-pill input-card-sm border mb-3">
             <div class="input-card-form">
               <label for="subscribeForm" class="form-label visually-hidden"
-                >ایمیل را وارد کنید</label
+                >{% trans "Enter email" %}</label
               >
               <input
                 type="text"
                 class="form-control form-control-lg"
                 id="subscribeForm"
-                placeholder="ایمیل خود را وارد کنید"
-                aria-label="ایمیل خود را وارد کنید"
+                placeholder="{% trans "Enter your email" %}"
+                aria-label="{% trans "Enter your email" %}"
               />
             </div>
             <button type="button" class="btn btn-primary btn-lg rounded-pill">
-              ثبت نام
+              {% trans "Sign up" %}
             </button>
           </div>
           <!-- End Input Card -->
         </form>
 
         <p class="small">
-          می توانید در هر زمانی اشتراک خود را لغو کنید
-          <a href="#">سیاست حفظ حریم خصوصی</a> ما را بخوانید
+          {% blocktrans trimmed %}You can unsubscribe at any time. Read our <a href="#">Privacy policy</a>.{% endblocktrans %}
         </p>
       </div>
     </div>
@@ -589,7 +591,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="submitReviewModalLabel">فرم ارسال دیدگاه</h5>
+                <h5 class="modal-title" id="submitReviewModalLabel">{% trans "Review submission form" %}</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
 
@@ -599,18 +601,18 @@
                     <input hidden name="product" value="{{object.id}}">
                     <div class="row">
                         <div class="mb-3">
-                            <label class="form-label" for="rateModalInput">امتیاز</label>
+                            <label class="form-label" for="rateModalInput">{% trans "Rating" %}</label>
                             <select class="form-select form-select-sm" name="rate" required>
-                                <option value="1">1 ستاره</option>
-                                <option value="2">2 ستاره</option>
-                                <option value="3">3 ستاره</option>
-                                <option value="4">4 ستاره</option>
-                                <option value="5" selected>5 ستاره</option>
+                                <option value="1">{% trans "1 star" %}</option>
+                                <option value="2">{% trans "2 stars" %}</option>
+                                <option value="3">{% trans "3 stars" %}</option>
+                                <option value="4">{% trans "4 stars" %}</option>
+                                <option value="5" selected>{% trans "5 stars" %}</option>
 
                             </select>
                         </div>
                         <div class="mb-3">
-                            <label class="form-label" for="descriptionModalInput">توضیحات</label>
+                            <label class="form-label" for="descriptionModalInput">{% trans "Description" %}</label>
                             <textarea type="text" class="form-control form-control-lg" id="descriptionModalInput"
                                 name="description" required> </textarea>
                         </div>
@@ -619,8 +621,8 @@
 
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">بستن</button>
-                <button class="btn btn-primary" type="submit" form="review-form">ثبت دیدگاه</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Close" %}</button>
+                <button class="btn btn-primary" type="submit" form="review-form">{% trans "Submit review" %}</button>
             </div>
         </div>
     </div>

--- a/core/templates/shop/products-grid.html
+++ b/core/templates/shop/products-grid.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 {% load humanize %}
+{% load i18n %}
 
 {% block content %}
     <!-- Breadcrumb -->
@@ -8,7 +9,7 @@
       <div class="container py-4">
         <div class="row">
           <div class="col-sm">
-            <h4 class="mb-0">شبکه محصولات</h4>
+            <h4 class="mb-0">{% trans "Product grid" %}</h4>
           </div>
           <!-- End Col -->
 
@@ -17,12 +18,12 @@
             <nav aria-label="breadcrumb">
               <ol class="breadcrumb mb-0 ">
                 <li class="breadcrumb-item ps-2">
-                  <a href="/index.html">خرید کنید</a>
+                  <a href="/index.html">{% trans "Shop" %}</a>
                 </li>
                 <li class="breadcrumb-item">
-                  <a href="/products-grid.html">محصولات</a>
+                  <a href="/products-grid.html">{% trans "Products" %}</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page">توری</li>
+                <li class="breadcrumb-item active" aria-current="page">{% trans "Grid" %}</li>
               </ol>
             </nav>
             <!-- End Breadcrumb -->
@@ -46,7 +47,7 @@
                     data-bs-target="#navbarVerticalNavMenu" aria-label="Toggle navigation" aria-expanded="false"
                     aria-controls="navbarVerticalNavMenu">
                     <span class="d-flex justify-content-between align-items-center">
-                        <span class="text-dark">فیلتر کنید</span>
+                        <span class="text-dark">{% trans "Filter" %}</span>
 
 
                         <span class="navbar-toggler-default">
@@ -66,38 +67,38 @@
                 <form action="." class="w-100">
 
                     <div class="border-bottom pb-4 mb-4">
-                        <h5>جستو جوی کالا</h5>
+                        <h5>{% trans "Product search" %}</h5>
                         <div class="d-grid gap-2">
                             <div class="form-group">
-                                <label class="form-label d-flex" for="search-query-filter">جستو جو</label>
-                                <input class="form-control" placeholder="واژه مورد نظر را وارد نمایید" type="text"
+                                <label class="form-label d-flex" for="search-query-filter">{% trans "Search" %}</label>
+                                <input class="form-control" placeholder="{% trans "Enter the desired term" %}" type="text"
                                     name="q" id="search-query-filter">
                             </div>
                         </div>
                     </div>
                     <div class="border-bottom pb-4 mb-4">
-                        <h5>قیمت</h5>
+                        <h5>{% trans "Price" %}</h5>
                         <div class="d-grid gap-2">
 
                             <div class="form-group">
-                                <label class="form-label d-flex" for="min-price-filter">کمترین قیمت</label>
+                                <label class="form-label d-flex" for="min-price-filter">{% trans "Minimum price" %}</label>
                                 <input class="form-control" type="number" name="min_price"
-                                    placeholder="کمترین قیمت مد نظر" id="min-price-filter">
+                                    placeholder="{% trans "Desired minimum price" %}" id="min-price-filter">
                             </div>
                             <div class="form-group">
-                                <label class="form-label d-flex" for="max-price-filter">بیشترین قیمت</label>
+                                <label class="form-label d-flex" for="max-price-filter">{% trans "Maximum price" %}</label>
                                 <input class="form-control" type="number" name="max_price"
-                                    placeholder="بیشترین قیمت مد نظر" id="max-price-filter">
+                                    placeholder="{% trans "Desired maximum price" %}" id="max-price-filter">
                             </div>
                         </div>
                     </div>
                     <div class="border-bottom pb-4 mb-4">
-                        <h5>دسته بندی</h5>
+                        <h5>{% trans "Category" %}</h5>
                         <div class="d-grid gap-2">
                             <div class="mb-2 mb-sm-0 me-sm-2">
                                 <select class="form-select form-select-sm" name="category_id"
                                     id="category-id-filter">
-                                    <option value="" selected>انتخاب دسته بندی</option>
+                                    <option value="" selected>{% trans "Select category" %}</option>
                                     {% for category in categories %}
                                     <option value="{{category.id}}">{{category.title}}</option>
                                     {% endfor %}
@@ -106,10 +107,10 @@
                         </div>
                     </div>
                     <div class="d-grid">
-                        <button type="submit" class="btn btn-outline-primary btn-transition mb-3">اعمال
-                            فیلتر</button>
+                        <button type="submit" class="btn btn-outline-primary btn-transition mb-3">{% trans "Apply filter" %}
+                        </button>
                         <a href="{% url 'shop:list_grid' %}"
-                            class="btn btn-outline-danger btn-transition mb-3">حذف فیلتر ها</a>
+                            class="btn btn-outline-danger btn-transition mb-3">{% trans "Clear filters" %}</a>
                     </div>
                 </form>
             </div>
@@ -122,7 +123,7 @@
         <div class="col-lg-9">
           <div class="row align-items-center mb-5">
             <div class="col-sm mb-3 mb-sm-0">
-              <h6 class="mb-0">{{total_prod}} محصول</h6>
+              <h6 class="mb-0">{% blocktrans count product_count=total_prod %}{{ product_count }} product{% plural %}{{ product_count }} products{% endblocktrans %}</h6>
             </div>
 
             <div class="col-sm-auto">
@@ -130,8 +131,8 @@
                 <!-- Select -->
                 <div class="mb-2 mb-sm-0 me-sm-2">
                   <select class="form-select form-select-sm" id="order-by-filter">
-                    <option value="-created_date" selected>جدیدترین</option>
-                    <option value="created_date">قدیمی ترین</option>
+                    <option value="-created_date" selected>{% trans "Newest" %}</option>
+                    <option value="created_date">{% trans "Oldest" %}</option>
                   </select>
                 </div>
                 <!-- End Select -->
@@ -139,7 +140,7 @@
                 <!-- Select -->
                 <div class="mb-2 mb-sm-0 me-sm-2">
                   <select class="form-select form-select-sm" id="page-size-filter">
-                    <option value="" selected>تعداد در صفحه</option>
+                    <option value="" selected>{% trans "Items per page" %}</option>
                     <option value="1">1</option>
                     <option value="20">20</option>
                     <option value="30">30</option>
@@ -177,14 +178,14 @@
                   <h6>{{object.product_image_related.all.first.image}}</h6>
                   {% if not object.stock %}
                   <div class="card-pinned-top-start">
-                    <span class="badge bg-danger rounded-pill">اتمام موجودی</span>
+                    <span class="badge bg-danger rounded-pill">{% trans "Out of stock" %}</span>
                   </div>
                   {% endif %}
 
                   {% if request.user.is_authenticated %}
                   <div class="card-pinned-top-end">
-                    <button type="button" class="btn btn-outline-danger btn-xs btn-icon rounded-circle {% if object.id in is_wished %}active{% endif %}" 
-                    data-bs-toggle="tooltip" data-bs-placement="top" title="افزودن به علایق" onclick="modify_wish(this,`{{object.id}}`)">
+                    <button type="button" class="btn btn-outline-danger btn-xs btn-icon rounded-circle {% if object.id in is_wished %}active{% endif %}"
+                    data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Add to wishlist' %}" onclick="modify_wish(this,`{{object.id}}`)">
                       <i class="bi-heart"></i>
                     </button>
                   </div>
@@ -195,7 +196,7 @@
                     {% for cat in object.category.all %}
                     <a class="link-sm link-secondary" href="#">{{cat}}</a>
                     {% if not forloop.last %}
-                      ،
+                      ,
                     {% endif %}
                     {% endfor %}
                   </div>
@@ -204,9 +205,9 @@
                     <a class="text-dark" href="{% url 'shop:detail' slug=object.slug %}">{{object.title}}</a>
                   </h4>
                   {% if object.discount_percent %}
-                  <p class="card-text text-dark">{{object.offer|intcomma}} <span class="text-body ms-1"><del>{{object.price|intcomma}} تومان</del></span></p>
+                  <p class="card-text text-dark">{{object.offer|intcomma}} {% trans "Toman" %} <span class="text-body ms-1"><del>{{object.price|intcomma}} {% trans "Toman" %}</del></span></p>
                   {% else %}
-                  <p class="card-text text-dark">{{object.price|intcomma}} تومان</p>
+                  <p class="card-text text-dark">{{object.price|intcomma}} {% trans "Toman" %}</p>
                   {% endif %}
                 </div>
 
@@ -225,9 +226,9 @@
                   </div>
                   <!-- End Rating -->
                    {% if not object.stock %}
-                   <button type="button" class="btn btn-outline-primary btn-sm btn-transition rounded-pill">موجود شد بهم اطلاع بده</button>
+                   <button type="button" class="btn btn-outline-primary btn-sm btn-transition rounded-pill">{% trans "Notify me when available" %}</button>
                    {% else %}
-                   <button type="button" class="btn btn-outline-primary btn-sm btn-transition rounded-pill" onclick="addProd(`{{object.id}}`)">افزودن به سبد خرید</button>
+                   <button type="button" class="btn btn-outline-primary btn-sm btn-transition rounded-pill" onclick="addProd(`{{object.id}}`)">{% trans "Add to cart" %}</button>
                    {% endif %}
                 </div>
               </div>
@@ -289,8 +290,8 @@
           <div class="row justify-content-lg-between">
             <!-- Heading -->
             <div class="mb-5">
-              <span class="text-cap">ثبت نام</span>
-              <h2>اخبار جدید را دریافت کنید</h2>
+              <span class="text-cap">{% trans "Sign up" %}</span>
+              <h2>{% trans "Get the latest news" %}</h2>
             </div>
             <!-- End Heading -->
 
@@ -298,15 +299,15 @@
               <!-- Input Card -->
               <div class="input-card input-card-pill input-card-sm border mb-3">
                 <div class="input-card-form">
-                  <label for="subscribeForm" class="form-label visually-hidden">ایمیل را وارد کنید</label>
-                  <input type="text" class="form-control form-control-lg" id="subscribeForm" placeholder="ایمیل خود را وارد کنید" aria-label="ایمیل خود را وارد کنید">
+                  <label for="subscribeForm" class="form-label visually-hidden">{% trans "Enter email" %}</label>
+                  <input type="text" class="form-control form-control-lg" id="subscribeForm" placeholder="{% trans "Enter your email" %}" aria-label="{% trans "Enter your email" %}">
                 </div>
-                <button type="button" class="btn btn-primary btn-lg rounded-pill">ثبت نام</button>
+                <button type="button" class="btn btn-primary btn-lg rounded-pill">{% trans "Sign up" %}</button>
               </div>
               <!-- End Input Card -->
             </form>
 
-            <p class="small">می توانید در هر زمانی اشتراک خود را لغو کنید <a href="#">سیاست حفظ حریم خصوصی</a> ما را بخوانید</p>
+            <p class="small">{% blocktrans trimmed %}You can unsubscribe at any time. Read our <a href="#">Privacy policy</a>.{% endblocktrans %}</p>
           </div>
         </div>
       </div>

--- a/core/templates/shop/products-list.html
+++ b/core/templates/shop/products-list.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 {% load humanize %}
+{% load i18n %}
 
 {% block content %}
     <!-- Breadcrumb -->
@@ -8,7 +9,7 @@
       <div class="container py-4">
         <div class="row">
           <div class="col-sm">
-            <h4 class="mb-0">شبکه محصولات</h4>
+            <h4 class="mb-0">{% trans "Product grid" %}</h4>
           </div>
           <!-- End Col -->
 
@@ -17,12 +18,12 @@
             <nav aria-label="breadcrumb">
               <ol class="breadcrumb mb-0 ">
                 <li class="breadcrumb-item ps-2">
-                  <a href="/index.html">خرید کنید</a>
+                  <a href="/index.html">{% trans "Shop" %}</a>
                 </li>
                 <li class="breadcrumb-item">
-                  <a href="/products-grid.html">محصولات</a>
+                  <a href="/products-grid.html">{% trans "Products" %}</a>
                 </li>
-                <li class="breadcrumb-item active" aria-current="page">توری</li>
+                <li class="breadcrumb-item active" aria-current="page">{% trans "Grid" %}</li>
               </ol>
             </nav>
             <!-- End Breadcrumb -->
@@ -44,7 +45,7 @@
             <div class="d-grid">
               <button type="button" class="navbar-toggler btn btn-white mb-3" data-bs-toggle="collapse" data-bs-target="#navbarVerticalNavMenu" aria-label="Toggle navigation" aria-expanded="false" aria-controls="navbarVerticalNavMenu">
                 <span class="d-flex justify-content-between align-items-center">
-                  <span class="text-dark">فیلتر کنید</span>
+                  <span class="text-dark">{% trans "Filter" %}</span>
 
                   <span class="navbar-toggler-default">
                     <i class="bi-list"></i>
@@ -63,38 +64,38 @@
               <form action="." class="w-100">
 
                   <div class="border-bottom pb-4 mb-4">
-                      <h5>جستو جوی کالا</h5>
+                      <h5>{% trans "Product search" %}</h5>
                       <div class="d-grid gap-2">
                           <div class="form-group">
-                              <label class="form-label d-flex" for="search-query-filter">جستو جو</label>
-                              <input class="form-control" placeholder="واژه مورد نظر را وارد نمایید" type="text"
+                              <label class="form-label d-flex" for="search-query-filter">{% trans "Search" %}</label>
+                              <input class="form-control" placeholder="{% trans "Enter the desired term" %}" type="text"
                                   name="q" id="search-query-filter">
                           </div>
                       </div>
                   </div>
                   <div class="border-bottom pb-4 mb-4">
-                      <h5>قیمت</h5>
+                      <h5>{% trans "Price" %}</h5>
                       <div class="d-grid gap-2">
 
                           <div class="form-group">
-                              <label class="form-label d-flex" for="min-price-filter">کمترین قیمت</label>
+                              <label class="form-label d-flex" for="min-price-filter">{% trans "Minimum price" %}</label>
                               <input class="form-control" type="number" name="min_price"
-                                  placeholder="کمترین قیمت مد نظر" id="min-price-filter">
+                                  placeholder="{% trans "Desired minimum price" %}" id="min-price-filter">
                           </div>
                           <div class="form-group">
-                              <label class="form-label d-flex" for="max-price-filter">بیشترین قیمت</label>
+                              <label class="form-label d-flex" for="max-price-filter">{% trans "Maximum price" %}</label>
                               <input class="form-control" type="number" name="max_price"
-                                  placeholder="بیشترین قیمت مد نظر" id="max-price-filter">
+                                  placeholder="{% trans "Desired maximum price" %}" id="max-price-filter">
                           </div>
                       </div>
                   </div>
                   <div class="border-bottom pb-4 mb-4">
-                      <h5>دسته بندی</h5>
+                      <h5>{% trans "Category" %}</h5>
                       <div class="d-grid gap-2">
                           <div class="mb-2 mb-sm-0 me-sm-2">
                               <select class="form-select form-select-sm" name="category_id"
                                   id="category-id-filter">
-                                  <option value="" selected>انتخاب دسته بندی</option>
+                                  <option value="" selected>{% trans "Select category" %}</option>
                                   {% for category in categories %}
                                   <option value="{{category.id}}">{{category.title}}</option>
                                   {% endfor %}
@@ -103,10 +104,10 @@
                       </div>
                   </div>
                   <div class="d-grid">
-                      <button type="submit" class="btn btn-outline-primary btn-transition mb-3">اعمال
-                          فیلتر</button>
+                      <button type="submit" class="btn btn-outline-primary btn-transition mb-3">{% trans "Apply filter" %}
+                          </button>
                       <a href="{% url 'shop:list' %}"
-                          class="btn btn-outline-danger btn-transition mb-3">حذف فیلتر ها</a>
+                          class="btn btn-outline-danger btn-transition mb-3">{% trans "Clear filters" %}</a>
                   </div>
               </form>
           </div>
@@ -119,7 +120,7 @@
         <div class="col-lg-9">
           <div class="row align-items-center mb-5">
             <div class="col-sm mb-3 mb-sm-0">
-              <h6 class="mb-0">{{total_prod}} محصول</h6>
+              <h6 class="mb-0">{% blocktrans count product_count=total_prod %}{{ product_count }} product{% plural %}{{ product_count }} products{% endblocktrans %}</h6>
             </div>
 
             <div class="col-sm-auto">
@@ -127,8 +128,8 @@
                 <!-- Select -->
                 <div class="mb-2 mb-sm-0 me-sm-2">
                   <select class="form-select form-select-sm" id="order-by-filter">
-                    <option value="-created_date" selected>جدیدترین</option>
-                    <option value="created_date">قدیمی ترین</option>
+                    <option value="-created_date" selected>{% trans "Newest" %}</option>
+                    <option value="created_date">{% trans "Oldest" %}</option>
                   </select>
                 </div>
                 <!-- End Select -->
@@ -136,7 +137,7 @@
                 <!-- Select -->
                 <div class="mb-2 mb-sm-0 me-sm-2">
                   <select class="form-select form-select-sm" id="page-size-filter">
-                    <option value="" selected>تعداد در صفحه</option>
+                    <option value="" selected>{% trans "Items per page" %}</option>
                     <option value="1">1</option>
                     <option value="20">20</option>
                     <option value="30">30</option>
@@ -174,7 +175,7 @@
                     <img class="card-img-top" src="{{ object.product_image_related.all.first.image.url }}" alt="Image Description">
                     {% if object.stock == 0 %}
                     <div class="card-pinned-top-start">
-                      <span class="badge bg-danger rounded-pill">اتمام موجودی</span>
+                      <span class="badge bg-danger rounded-pill">{% trans "Out of stock" %}</span>
                     </div>
                     {% endif %}
                   </div>
@@ -187,7 +188,7 @@
                       {% for cat in object.category.all %}
                       <a class="link-sm link-secondary" href="#">{{cat}}</a>
                       {% if not forloop.last %}
-                        ،
+                        ,
                       {% endif %}
                       {% endfor %}
                     </div>
@@ -197,9 +198,9 @@
                         <a class="text-dark" href="/product-overview.html">{{object.title}}</a>
                       </h4>
                       {% if object.discount_percent %}
-                      <p class="card-text text-dark">{{object.offer|intcomma}} تومان<span class="text-body ms-1"><del>{{object.price|intcomma}} تومان</del></span></p>
+                      <p class="card-text text-dark">{{object.offer|intcomma}} {% trans "Toman" %}<span class="text-body ms-1"><del>{{object.price|intcomma}} {% trans "Toman" %}</del></span></p>
                       {% else %}
-                      <p class="card-text text-dark">{{object.price|intcomma}} تومان</p>
+                      <p class="card-text text-dark">{{object.price|intcomma}} {% trans "Toman" %}</p>
                       {% endif %}
                     </div>
 
@@ -220,14 +221,14 @@
                     <div class="card-footer">
                       <div class="d-flex gap-2">
                         {% if not object.stock %}
-                        <button type="button" class="btn btn-outline-primary btn-sm btn-transition rounded-pill">موجود شد بهم اطلاع بده</button>
+                        <button type="button" class="btn btn-outline-primary btn-sm btn-transition rounded-pill">{% trans "Notify me when available" %}</button>
                         {% else %}
-                        <button type="button" class="btn btn-outline-primary btn-sm btn-transition rounded-pill" onclick="addProd(`{{object.id}}`)">افزودن به سبد خرید</button>
+                        <button type="button" class="btn btn-outline-primary btn-sm btn-transition rounded-pill" onclick="addProd(`{{object.id}}`)">{% trans "Add to cart" %}</button>
                         {% endif %}
                         {% if request.user.is_authenticated %}
                         <button type="button" class="btn btn-soft-danger btn-sm btn-transition rounded-pill {% if object.id in is_wished %}active{% endif %}"
                         onclick="modify_wish(this,`{{object.id}}`)">
-                          <i class="bi-heart ms-1"></i>افزودن به علایق</button>
+                          <i class="bi-heart ms-1"></i>{% trans "Add to wishlist" %}</button>
                         {% endif %}
                       </div>
                     </div>
@@ -291,8 +292,8 @@
           <div class="row justify-content-lg-between">
             <!-- Heading -->
             <div class="mb-5">
-              <span class="text-cap">ثبت نام</span>
-              <h2>اخبار جدید را دریافت کنید</h2>
+              <span class="text-cap">{% trans "Sign up" %}</span>
+              <h2>{% trans "Get the latest news" %}</h2>
             </div>
             <!-- End Heading -->
 
@@ -300,15 +301,15 @@
               <!-- Input Card -->
               <div class="input-card input-card-pill input-card-sm border mb-3">
                 <div class="input-card-form">
-                  <label for="subscribeForm" class="form-label visually-hidden">ایمیل را وارد کنید</label>
-                  <input type="text" class="form-control form-control-lg" id="subscribeForm" placeholder="ایمیل خود را وارد کنید" aria-label="ایمیل خود را وارد کنید">
+                  <label for="subscribeForm" class="form-label visually-hidden">{% trans "Enter email" %}</label>
+                  <input type="text" class="form-control form-control-lg" id="subscribeForm" placeholder="{% trans "Enter your email" %}" aria-label="{% trans "Enter your email" %}">
                 </div>
-                <button type="button" class="btn btn-primary btn-lg rounded-pill">ثبت نام</button>
+                <button type="button" class="btn btn-primary btn-lg rounded-pill">{% trans "Sign up" %}</button>
               </div>
               <!-- End Input Card -->
             </form>
 
-            <p class="small">می توانید در هر زمانی اشتراک خود را لغو کنید <a href="#">سیاست حفظ حریم خصوصی</a> ما را بخوانید</p>
+            <p class="small">{% blocktrans trimmed %}You can unsubscribe at any time. Read our <a href="#">Privacy policy</a>.{% endblocktrans %}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- translate the shared include snippets to English and wrap their labels in Django translation tags
- update the order templates with English messaging, translation helpers, and localized coupon feedback
- localize the shop product detail, grid, and list templates, including filters, pricing, and subscribe sections

## Testing
- poetry run python manage.py check *(fails: Poetry configuration not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e447ff446c8320a864b874e74d0f6b