### PR TITLE
Translate site content to English and add localization hooks

### DIFF
--- a/core/accounts/forms.py
+++ b/core/accounts/forms.py
@@ -21,13 +21,13 @@ class CustomAuthenticationForm(AuthenticationForm):
     captcha = ReCaptchaField(widget=ReCaptchaV3)
 
     error_messages = {
-        "invalid_login": "ایمیل یا پسوورد اشتباه میباشد",
+        "invalid_login": _("Please enter a correct email address and password."),
         # 'inactive': "This account is inactive. Contact support for assistance.",
     }
 
     def confirm_login_allowed(self, user):
         if not user.is_verified:
-            raise forms.ValidationError("اکانت شما هنوز تایید نشده است")
+            raise forms.ValidationError(_("Your account has not been verified yet."))
 
 
 class SetPasswordForm(forms.Form):

--- a/core/accounts/models.py
+++ b/core/accounts/models.py
@@ -90,7 +90,7 @@ class Profile(models.Model):
     def get_fullname(self):
         if self.first_name or self.last_name:
             return self.first_name + " " + self.last_name
-        return "کاربر جدید"
+        return _("New user")
 
 
 @receiver(post_save, sender=User)

--- a/core/accounts/views.py
+++ b/core/accounts/views.py
@@ -1,14 +1,15 @@
-from django.contrib.auth import views as auth_views
-from django.contrib.auth import login
-from django.views.generic import CreateView
-from .forms import CustomAuthenticationForm, RegistrationForm
+from django.contrib.auth import login, views as auth_views
 from django.contrib.messages.views import SuccessMessageMixin
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import CreateView
+
+from .forms import CustomAuthenticationForm, RegistrationForm
 
 
 class SignUpView(SuccessMessageMixin, CreateView):
     template_name = "accounts/signup.html"
     form_class = RegistrationForm
-    success_message = "ثبت نام کاربر با موفقیت انجام شد"
+    success_message = _("User registration completed successfully")
     success_url = "/"
 
     def form_valid(self, form):
@@ -22,7 +23,7 @@ class LoginView(SuccessMessageMixin, auth_views.LoginView):
     template_name = "accounts/login.html"
     form_class = CustomAuthenticationForm
     redirect_authenticated_user = True
-    success_message = "کاربر با موفقیت وارد شد"
+    success_message = _("Signed in successfully")
 
 
 class LogoutView(auth_views.LogoutView):

--- a/core/cart/views.py
+++ b/core/cart/views.py
@@ -1,5 +1,6 @@
-from django.views.generic import View, TemplateView
 from django.http import JsonResponse
+from django.utils.translation import gettext as _
+from django.views.generic import TemplateView, View
 from .cart import CartSession
 
 
@@ -14,7 +15,7 @@ class AddProdView(View):
             {
                 "cart": cart.get_cart(),
                 "total_quantity": cart.get_cart_quantity(),
-                "message": "!!محصول به سبد خرید اضافه شد",
+                "message": _("Product added to the cart!"),
             }
         )
 

--- a/core/dashboard/admin/forms/coupon.py
+++ b/core/dashboard/admin/forms/coupon.py
@@ -1,4 +1,6 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
+
 from order.models import CouponModel
 
 
@@ -16,16 +18,16 @@ class AdminCouponForm(forms.ModelForm):
         self.fields["code"].widget.attrs["class"] = "form-control text-center"
         self.fields["code"].widget.attrs[
             "placeholder"
-        ] = "کد تخفیف را وارد نمایید"
+        ] = _("Enter the discount code")
         self.fields["discount_percent"].widget.attrs[
             "class"
         ] = "form-control text-center"
         self.fields["discount_percent"].widget.attrs[
             "placeholder"
-        ] = "مقدار تخفیف"
+        ] = _("Discount amount")
         self.fields["max_limit_usage"].widget.attrs[
             "class"
         ] = "form-control text-center"
         self.fields["max_limit_usage"].widget.attrs[
             "placeholder"
-        ] = "حداکثر تعداد استفاده"
+        ] = _("Maximum usage")

--- a/core/dashboard/admin/forms/profile.py
+++ b/core/dashboard/admin/forms/profile.py
@@ -1,5 +1,7 @@
 from django import forms
 from django.contrib.auth.forms import PasswordChangeForm
+from django.utils.translation import gettext_lazy as _
+
 from accounts.models import Profile
 
 
@@ -21,10 +23,10 @@ class ProfileForm(forms.ModelForm):
         ] = "form-control text-center"
         self.fields["first_name"].widget.attrs[
             "placeholder"
-        ] = "نام خود را وارد نمایید"
+        ] = _("Enter your first name")
         self.fields["last_name"].widget.attrs[
             "placeholder"
-        ] = "نام خانوادگی را وارد نمایید"
+        ] = _("Enter your last name")
         self.fields["phone_number"].widget.attrs[
             "placeholder"
-        ] = "شماره همراه را وارد نمایید"
+        ] = _("Enter your phone number")

--- a/core/dashboard/admin/views/coupon.py
+++ b/core/dashboard/admin/views/coupon.py
@@ -1,13 +1,16 @@
-from django.views.generic import ListView, CreateView
-from django.urls import reverse_lazy
-from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import FieldError
+from django.db.models import Count, F
+from django.urls import reverse_lazy
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import CreateView, ListView
+
+from order.models import CouponModel
+
 from ...permissions import AdminPermissions
 from ..forms import AdminCouponForm
-from order.models import CouponModel
 from ..forms import *
-from django.db.models import Count, F
 
 
 class AdminCouponView(LoginRequiredMixin, AdminPermissions, ListView):
@@ -47,4 +50,4 @@ class AdminCouponCreateView(
     template_name = "dashboard/admin/coupons/coupon-create.html"
     form_class = AdminCouponForm
     success_url = reverse_lazy("dashboard:admin:coupon-list")
-    success_message = "کد تخفیف با موفقیت ایجاد شد"
+    success_message = _("Coupon created successfully")

--- a/core/dashboard/admin/views/member.py
+++ b/core/dashboard/admin/views/member.py
@@ -1,11 +1,14 @@
-from django.views.generic import UpdateView, ListView
-from django.urls import reverse_lazy
-from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import FieldError
+from django.urls import reverse_lazy
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import ListView, UpdateView
+
+from accounts.models import User, UserType
+
 from ...permissions import AdminPermissions
 from ..forms import *
-from accounts.models import User, UserType
 
 
 class AdminMemberListView(LoginRequiredMixin, AdminPermissions, ListView):
@@ -38,7 +41,7 @@ class AdminMemberEditView(
 ):
     template_name = "dashboard/admin/members/member-edit.html"
     form_class = AdminMemberEditForm
-    success_message = "کاربر با موفقیت ویرایش شد"
+    success_message = _("User updated successfully")
 
     def get_queryset(self):
         return (

--- a/core/dashboard/admin/views/ticket.py
+++ b/core/dashboard/admin/views/ticket.py
@@ -1,11 +1,13 @@
-from django.views.generic import ListView, DeleteView, DetailView
-from django.urls import reverse_lazy
-from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import FieldError
+from django.urls import reverse_lazy
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import DeleteView, DetailView, ListView
+
+from ...models import TicketModel
 from ...permissions import AdminPermissions
 from ..forms import *
-from ...models import TicketModel
 
 
 class AdminTicketListView(LoginRequiredMixin, AdminPermissions, ListView):
@@ -41,4 +43,4 @@ class AdminTicketDeleteView(
     queryset = TicketModel.objects.all()
     template_name = "dashboard/admin/tickets/ticket-delete.html"
     success_url = reverse_lazy("dashboard:admin:ticket-list")
-    success_message = "تیکت با موفقیت حذف شد"
+    success_message = _("Ticket deleted successfully")

--- a/core/dashboard/customer/forms/profile.py
+++ b/core/dashboard/customer/forms/profile.py
@@ -1,5 +1,7 @@
 from django import forms
 from django.contrib.auth.forms import PasswordChangeForm
+from django.utils.translation import gettext_lazy as _
+
 from accounts.models import Profile
 
 
@@ -21,10 +23,10 @@ class ProfileForm(forms.ModelForm):
         ] = "form-control text-center"
         self.fields["first_name"].widget.attrs[
             "placeholder"
-        ] = "نام خود را وارد نمایید"
+        ] = _("Enter your first name")
         self.fields["last_name"].widget.attrs[
             "placeholder"
-        ] = "نام خانوادگی را وارد نمایید"
+        ] = _("Enter your last name")
         self.fields["phone_number"].widget.attrs[
             "placeholder"
-        ] = "شماره همراه را وارد نمایید"
+        ] = _("Enter your phone number")

--- a/core/dashboard/customer/views/address.py
+++ b/core/dashboard/customer/views/address.py
@@ -1,10 +1,13 @@
 from django.views.generic import ListView, CreateView, UpdateView, DeleteView
-from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.messages.views import SuccessMessageMixin
 from django.urls import reverse_lazy
+from django.utils.translation import gettext_lazy as _
+
+from order.models import AddressModel
+
 from ...permissions import CustomerPermissions
 from ..forms import *
-from order.models import AddressModel
 
 
 class AddressesView(LoginRequiredMixin, CustomerPermissions, ListView):
@@ -21,7 +24,7 @@ class AddAddressesView(
 ):
     form_class = AddAddressesForm
     template_name = "dashboard/customer/orders/add-addresses.html"
-    success_message = "آدرس با موفقیت ذخیره شد"
+    success_message = _("Address saved successfully")
     success_url = reverse_lazy("dashboard:customer:addresses")
 
     def form_valid(self, form):
@@ -35,7 +38,7 @@ class ChangeAddressesView(
     template_name = "dashboard/customer/orders/change-addresses.html"
     form_class = AddAddressesForm
     success_url = reverse_lazy("dashboard:customer:addresses")
-    success_message = "Profile changed successfully"
+    success_message = _("Profile changed successfully")
 
     def get_object(self, queryset=None):
         return AddressModel.objects.get(

--- a/core/dashboard/customer/views/profile.py
+++ b/core/dashboard/customer/views/profile.py
@@ -1,9 +1,12 @@
-from django.views.generic import TemplateView, UpdateView
-from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import PasswordChangeView
+from django.contrib.messages.views import SuccessMessageMixin
 from django.urls import reverse_lazy
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import TemplateView, UpdateView
+
 from accounts.models import User
+
 from ...permissions import CustomerPermissions
 from ..forms import *
 
@@ -28,7 +31,7 @@ class ChangePassView(
     template_name = "dashboard/customer/profile/change-pass.html"
     form_class = ChangePassForm
     success_url = reverse_lazy("dashboard:customer:change-pass")
-    success_message = "گذرواژه با موفقیت تغییر کرد"
+    success_message = _("Password changed successfully")
 
 
 class ProfileView(
@@ -37,7 +40,7 @@ class ProfileView(
     template_name = "dashboard/customer/profile/profile.html"
     form_class = ProfileForm
     success_url = reverse_lazy("dashboard:customer:profile")
-    success_message = "پروفایل شما با موفقیت تغییر کرد"
+    success_message = _("Your profile has been updated successfully")
 
     def get_object(self, queryset=None):
         return Profile.objects.get(user=self.request.user)

--- a/core/dashboard/customer/views/wishlist.py
+++ b/core/dashboard/customer/views/wishlist.py
@@ -1,10 +1,13 @@
-from django.views.generic import ListView, DeleteView
-from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.messages.views import SuccessMessageMixin
 from django.urls import reverse_lazy
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import DeleteView, ListView
+
+from shop.models import WishListModel
+
 from ...permissions import CustomerPermissions
 from ..forms import *
-from shop.models import WishListModel
 
 
 class WishListView(LoginRequiredMixin, CustomerPermissions, ListView):
@@ -27,7 +30,7 @@ class DeleteWishView(
 ):
     http_method_names = ["post"]
     success_url = reverse_lazy("dashboard:customer:wishlist")
-    success_message = "محصول از لیست علایق حذف شد"
+    success_message = _("Product removed from wishlist")
 
     def get_queryset(self):
         return WishListModel.objects.filter(user=self.request.user)

--- a/core/dashboard/views.py
+++ b/core/dashboard/views.py
@@ -1,10 +1,11 @@
-from django.views.generic import View, UpdateView
 from django.contrib.auth.mixins import LoginRequiredMixin
-from accounts.models import UserType
 from django.contrib.messages.views import SuccessMessageMixin
-from accounts.models import Profile
-from django.urls import reverse_lazy
 from django.shortcuts import redirect
+from django.urls import reverse_lazy
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import UpdateView, View
+
+from accounts.models import Profile, UserType
 
 
 class DashboardCheckView(LoginRequiredMixin, View):
@@ -22,7 +23,7 @@ class ProfileEditView(UpdateView, SuccessMessageMixin):
     model = Profile
     fields = ["avatar"]
     success_url = reverse_lazy("dashboard:check")
-    success_message = "عکس پروفایل شما با موفقیت تغییر کرد"
+    success_message = _("Your profile picture has been updated successfully")
 
     def get_object(self, queryset=None):
         return Profile.objects.get(user=self.request.user)

--- a/core/order/forms.py
+++ b/core/order/forms.py
@@ -1,4 +1,6 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
+
 from order.models import AddressModel, CouponModel
 
 
@@ -17,7 +19,7 @@ class CheckOutForm(forms.Form):
                 id=address_id, user=self.request.user
             )
         except AddressModel.DoesNotExist:
-            raise forms.ValidationError("آدرس با اطلاعات کاربر تطابق ندارد")
+            raise forms.ValidationError(_("The address does not match the current user."))
 
         return address
 
@@ -30,13 +32,13 @@ class CheckOutForm(forms.Form):
         try:
             coupon = CouponModel.objects.get(code=coupon_code)
         except CouponModel.DoesNotExist:
-            raise forms.ValidationError("کد وارد شده اشتباه است")
+            raise forms.ValidationError(_("The code you entered is incorrect."))
 
         if coupon:
             if self.request.user in coupon.used_by.all():
                 raise forms.ValidationError(
-                    "این کد توسط شما یک بار استفاده شده است"
+                    _("You have already used this code once.")
                 )
             if coupon.max_limit_usage == 0:
-                raise forms.ValidationError("کد دیگر فاقد ارزش است")
+                raise forms.ValidationError(_("This code is no longer valid."))
         return coupon

--- a/core/order/models.py
+++ b/core/order/models.py
@@ -3,10 +3,13 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from decimal import Decimal
 
 
+from django.utils.translation import gettext_lazy as _
+
+
 class OrderStatusModel(models.IntegerChoices):
-    pending = 1, "در انتظار پرداخت"
-    success = 2, "موفقیت آمیز"
-    faild = 3, "لغو شده"
+    pending = 1, _("Pending payment")
+    success = 2, _("Successful")
+    faild = 3, _("Cancelled")
 
 
 class AddressModel(models.Model):

--- a/core/payment/models.py
+++ b/core/payment/models.py
@@ -1,10 +1,11 @@
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 
 class PaymentStatus(models.IntegerChoices):
-    pending = 1, "در حال انتظار"
-    success = 2, "موفق"
-    faild = 3, "نا موفق"
+    pending = 1, _("Pending")
+    success = 2, _("Successful")
+    faild = 3, _("Failed")
 
 
 class PaymentModel(models.Model):

--- a/core/payment/zarinpal_client.py
+++ b/core/payment/zarinpal_client.py
@@ -1,6 +1,8 @@
-import requests
 import json
+
+import requests
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
 
 class ZarinPalSandbox:
@@ -15,7 +17,7 @@ class ZarinPalSandbox:
     def __init__(self, merchant_id=settings.MERCHANT_ID):
         self.merchant_id = merchant_id
 
-    def payment_request(self, amount, description="درگاه پرداخت"):
+    def payment_request(self, amount, description=_("Payment gateway")):
         payload = {
             "merchant_id": self.merchant_id,
             "amount": int(amount),

--- a/core/review/forms.py
+++ b/core/review/forms.py
@@ -1,4 +1,6 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
+
 from .models import ReviewModel
 
 
@@ -9,6 +11,6 @@ class ReviewForm(forms.ModelForm):
 
         error_messages = {
             "description": {
-                "required": "فیلد توضیحات اجباری است",
+                "required": _("The description field is required."),
             },
         }

--- a/core/review/views.py
+++ b/core/review/views.py
@@ -1,8 +1,9 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.views.generic import CreateView
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
+from django.utils.translation import gettext as _
+from django.views.generic import CreateView
 from .models import ReviewModel
 from .forms import ReviewForm
 
@@ -15,7 +16,7 @@ class ReviewView(LoginRequiredMixin, CreateView):
     def form_valid(self, form):
         form.instance.user = self.request.user
         form.save()
-        messages.success(self.request, "دیدگاه شما با موفقیت ثبت شد")
+        messages.success(self.request, _("Your review has been submitted successfully."))
         return redirect(
             reverse_lazy(
                 "shop:detail", kwargs={"slug": form.instance.product.slug}

--- a/core/shop/models.py
+++ b/core/shop/models.py
@@ -1,12 +1,13 @@
 from django.db import models
 from django.core.validators import MaxValueValidator, MinValueValidator
-from django_ckeditor_5.fields import CKEditor5Field
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+from django_ckeditor_5.fields import CKEditor5Field
 
 
 class ProductStatus(models.IntegerChoices):
-    active = 1, "فعال"
-    deactive = 2, "غیرفعال"
+    active = 1, _("Active")
+    deactive = 2, _("Inactive")
 
 
 class CategoryModel(models.Model):

--- a/core/shop/views.py
+++ b/core/shop/views.py
@@ -1,12 +1,16 @@
 from django.views import generic
-from django.db.models import Count, Q
-from review.models import ReviewModel
-from .models import ProductModel, ProductStatus, CategoryModel, WishListModel
 from django.core.exceptions import FieldError
-from cart.cart import CartSession
+from django.db.models import Count, Q
 from django.http import JsonResponse
-from django.views.decorators.cache import cache_page
 from django.utils.decorators import method_decorator
+from django.utils.translation import gettext as _
+from django.views import generic
+from django.views.decorators.cache import cache_page
+
+from cart.cart import CartSession
+from review.models import ReviewModel
+
+from .models import CategoryModel, ProductModel, ProductStatus, WishListModel
 
 
 # @method_decorator(cache_page(60 * 15), name="dispatch")
@@ -122,8 +126,8 @@ class AddOrRemoveWish(generic.View):
             wish_obj, created = WishListModel.objects.get_or_create(
                 user=request.user, product_id=product_id
             )
-            message = "محصول به لیست علایق اضافه شد"
+            message = _("Product added to wishlist")
             if not created:
                 wish_obj.delete()
-                message = "محصول از لیست علایق حذف شد"
+                message = _("Product removed from wishlist")
         return JsonResponse({"message": message})

--- a/core/templates/404.html
+++ b/core/templates/404.html
@@ -1,14 +1,14 @@
-{% load static %}
+{% load static i18n %}
 
 <!DOCTYPE html>
-<html lang="fa" dir="" class="h-100">
+<html lang="en" dir="ltr" class="h-100">
 <head>
   <!-- Required Meta Tags Always Come First -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
   <!-- Title -->
-  <title>خطای 404 | جلو - قالب چند منظوره پاسخگو</title>
+  <title>{% trans "Error 404 | Front - Responsive Multipurpose Template" %}</title>
 
   <!-- Font -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
@@ -45,11 +45,11 @@
       </div>
 
       <div class="mb-4">
-        <p class="fs-4 mb-0">اوه! به نظر می رسد لینک بدی را دنبال کرده اید.</p>
-        <p class="fs-4">اگر فکر می کنید این مشکل با ماست، لطفا <a class="link" href="#">به ما بگو</a>.</p>
+        <p class="fs-4 mb-0">{% trans "Oops! It looks like you followed a bad link." %}</p>
+        <p class="fs-4">{% trans "If you think this is an issue on our side, please" %} <a class="link" href="#">{% trans "tell us" %}</a>.</p>
       </div>
 
-      <a class="btn btn-primary" href="{% url 'website:home' %}">به خانه برگرد</a>
+      <a class="btn btn-primary" href="{% url 'website:home' %}">{% trans "Go back home" %}</a>
     </div>
     <!-- End Content -->
   </main>
@@ -60,7 +60,7 @@
     <div class="container pb-5 content-space-b-sm-1">
       <div class="row justify-content-between align-items-center">
         <div class="col-sm mb-3 mb-sm-0">
-          <p class="small mb-0">&copy; جلو. Htmlstream 2021.</p>
+          <p class="small mb-0">&copy; {% trans "Front. Htmlstream 2021." %}</p>
         </div>
 
         <div class="col-sm-auto">

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -1,7 +1,7 @@
-{% load static %}
+{% load static i18n %}
 
 <!DOCTYPE html>
-<html lang="fa" dir="rtl">
+<html lang="en" dir="ltr">
 
 <head>
   <!-- Required Meta Tags Always Come First -->
@@ -9,7 +9,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
   <!-- Title -->
-  <title>{% block title %}خانه{% endblock title %}</title>
+  <title>{% block title %}{% trans "Home" %}{% endblock title %}</title>
 
   <!-- Font -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
@@ -39,7 +39,7 @@
   
           <!-- Toggler -->
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown"
-            aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+            aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="{% trans 'Toggle navigation' %}">
             <span class="navbar-toggler-default">
               <i class="bi-list"></i>
             </span>
@@ -53,16 +53,16 @@
           <div class="collapse navbar-collapse" id="navbarNavDropdown">
             <ul class="navbar-nav">
               <li class="nav-item">
-                <a class="nav-link {% if request.resolver_match.view_name == 'website:home' %} active {% endif %}" href="{% url 'website:home' %}">صفحه اصلی</a>
+                <a class="nav-link {% if request.resolver_match.view_name == 'website:home' %} active {% endif %}" href="{% url 'website:home' %}">{% trans "Home" %}</a>
               </li>
               <li class="nav-item">
-                <a class="nav-link {% if request.resolver_match.view_name == 'shop:list_grid' %} active {% endif %}" href="{% url 'shop:list_grid' %}">مشاهده محصولات</a>
+                <a class="nav-link {% if request.resolver_match.view_name == 'shop:list_grid' %} active {% endif %}" href="{% url 'shop:list_grid' %}">{% trans "Browse products" %}</a>
               </li>
               <li class="nav-item">
-                <a class="nav-link {% if request.resolver_match.view_name == 'website:about' %} active {% endif %}" href="{% url 'website:about' %}">درباره ما</a>
+                <a class="nav-link {% if request.resolver_match.view_name == 'website:about' %} active {% endif %}" href="{% url 'website:about' %}">{% trans "About us" %}</a>
               </li>
               <li class="nav-item">
-                <a class="nav-link {% if request.resolver_match.view_name == 'website:contact' %} active {% endif %}" href="{% url 'website:contact' %}">ارتباط با ما</a>
+                <a class="nav-link {% if request.resolver_match.view_name == 'website:contact' %} active {% endif %}" href="{% url 'website:contact' %}">{% trans "Contact us" %}</a>
               </li>
               <li class="nav-item">
                 <!-- Search -->
@@ -89,11 +89,11 @@
                 </button>
 
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-                <a class="dropdown-item" href="{% url 'dashboard:check' %}">پروفایل</a>
-                <a class="dropdown-item" href="{% url 'logout' %}">خروج</a>
+                <a class="dropdown-item" href="{% url 'dashboard:check' %}">{% trans "Profile" %}</a>
+                <a class="dropdown-item" href="{% url 'logout' %}">{% trans "Log out" %}</a>
                 </div>
                 {% else %}
-                <a class="btn btn-primary btn-transition" href="{% url 'login' %}">ورود</a>
+                <a class="btn btn-primary btn-transition" href="{% url 'login' %}">{% trans "Log in" %}</a>
                 {% endif %}
               </li>
             </ul>
@@ -121,44 +121,44 @@
             </a>
             <!-- End Logo -->
 
-            <p class="text-muted small mb-0">&copy; Benyamin 2023 Front RTL</p>
+            <p class="text-muted small mb-0">&copy; {% trans "Benyamin 2023 Front RTL" %}</p>
           </div>
         </div>
 
         <div class="col-6 col-md-4 col-lg-3 ms-lg-auto mb-5 mb-lg-0">
-          <h5>حساب</h5>
+          <h5>{% trans "Account" %}</h5>
 
           <!-- List -->
           <ul class="list-unstyled list-py-1">
-            <li><a class="link-sm text-secondary" href="#">سفارش دادن</a></li>
-            <li><a class="link-sm text-secondary" href="#">گزینه های حمل و نقل</a></li>
-            <li><a class="link-sm text-secondary" href="#">پیگیری یک بسته</a></li>
-            <li><a class="link-sm text-secondary" href="#">در دسترس بودن کشور</a></li>
+            <li><a class="link-sm text-secondary" href="#">{% trans "Place an order" %}</a></li>
+            <li><a class="link-sm text-secondary" href="#">{% trans "Shipping options" %}</a></li>
+            <li><a class="link-sm text-secondary" href="#">{% trans "Track a package" %}</a></li>
+            <li><a class="link-sm text-secondary" href="#">{% trans "Country availability" %}</a></li>
           </ul>
           <!-- End List -->
         </div>
         <!-- End Col -->
 
         <div class="col-6 col-md-4 col-lg-3 mb-5 mb-lg-0">
-          <h5>شرکت</h5>
+          <h5>{% trans "Company" %}</h5>
 
           <!-- List -->
           <ul class="list-unstyled list-py-1">
-            <li><a class="link-sm text-secondary" href="#">تامین مالی</a></li>
-            <li><a class="link-sm text-secondary" href="#">بازیافت</a></li>
-            <li><a class="link-sm text-secondary" href="#">سیاست بازگشت</a></li>
+            <li><a class="link-sm text-secondary" href="#">{% trans "Financing" %}</a></li>
+            <li><a class="link-sm text-secondary" href="#">{% trans "Recycling" %}</a></li>
+            <li><a class="link-sm text-secondary" href="#">{% trans "Return policy" %}</a></li>
           </ul>
           <!-- End List -->
         </div>
         <!-- End Col -->
 
         <div class="col-md-4 col-lg-2 mb-5 mb-lg-0">
-          <h5 class="mb-3">منابع</h5>
+          <h5 class="mb-3">{% trans "Resources" %}</h5>
 
           <!-- List -->
           <ul class="list-unstyled list-py-1">
-            <li><a class="link-sm link-secondary" href="#"><i class="bi-question-circle-fill me-1"></i> کمک</a></li>
-            <li><a class="link-sm link-secondary" href="#"><i class="bi-person-circle me-1"></i> حساب شما</a></li>
+            <li><a class="link-sm link-secondary" href="#"><i class="bi-question-circle-fill me-1"></i> {% trans "Help" %}</a></li>
+            <li><a class="link-sm link-secondary" href="#"><i class="bi-person-circle me-1"></i> {% trans "Your account" %}</a></li>
           </ul>
           <!-- End List -->
 
@@ -169,7 +169,7 @@
               <span class="d-flex align-items-center">
                 <img class="avatar avatar-xss avatar-circle ms-2" src="{% static 'vendor/flag-icon-css/flags/1x1/us.svg' %}"
                   alt="Image description" width="16" />
-                <span>انگلیسی (US)</span>
+                <span>{% trans "English (US)" %}</span>
               </span>
             </button>
 
@@ -177,22 +177,22 @@
               <a class="dropdown-item d-flex align-items-center active" href="#">
                 <img class="avatar avatar-xss avatar-circle ms-2" src="{% static 'vendor/flag-icon-css/flags/1x1/us.svg' %}"
                   alt="Image description" width="16" />
-                <span>انگلیسی</span>
+                <span>{% trans "English" %}</span>
               </a>
               <a class="dropdown-item d-flex align-items-center" href="#">
                 <img class="avatar avatar-xss avatar-circle ms-2" src="{% static 'vendor/flag-icon-css/flags/1x1/de.svg' %}"
                   alt="Image description" width="16" />
-                <span>آلمانی</span>
+                <span>{% trans "German" %}</span>
               </a>
               <a class="dropdown-item d-flex align-items-center" href="#">
                 <img class="avatar avatar-xss avatar-circle ms-2" src="{% static 'vendor/flag-icon-css/flags/1x1/es.svg' %}"
                   alt="Image description" width="16" />
-                <span>اسپانیایی</span>
+                <span>{% trans "Spanish" %}</span>
               </a>
               <a class="dropdown-item d-flex align-items-center" href="#">
                 <img class="avatar avatar-xss avatar-circle ms-2" src="{% static 'vendor/flag-icon-css/flags/1x1/cn.svg' %}"
                   alt="Image description" width="16" />
-                <span>چینی</span>
+                <span>{% trans "Chinese" %}</span>
               </a>
             </div>
           </div>
@@ -240,7 +240,7 @@
             <div class="container">
               <div class="w-lg-75 mx-lg-auto">
                 <div class="d-flex justify-content-end mb-3">
-                  <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                  <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="{% trans 'Close' %}"></button>
                 </div>
 
                 <div class="mb-7">
@@ -249,10 +249,10 @@
                     <!-- Input Card -->
                     <div class="input-card">
                       <div class="input-card-form">
-                        <input type="text" class="form-control form-control-lg" placeholder="جستجو محصولات"
-                          aria-label="جستجو محصولات" name="q">
+                        <input type="text" class="form-control form-control-lg" placeholder="{% trans 'Search products' %}"
+                          aria-label="{% trans 'Search products' %}" name="q">
                       </div>
-                      <button type="submit" class="btn btn-primary btn-lg">جستجو کردن</button>
+                      <button type="submit" class="btn btn-primary btn-lg">{% trans "Search" %}</button>
                     </div>
                     <!-- End Input Card -->
                   </form>
@@ -270,13 +270,13 @@
           <!-- List -->
           <ul class="list-inline list-separator">
             <li class="list-inline-item">
-              <a class="link-sm link-secondary" href="/page-privacy.html">حریم خصوصی و خط مشی</a>
+              <a class="link-sm link-secondary" href="/page-privacy.html">{% trans "Privacy policy" %}</a>
             </li>
             <li class="list-inline-item">
-              <a class="link-sm link-secondary" href="/page-terms.html">مقررات و شرایط</a>
+              <a class="link-sm link-secondary" href="/page-terms.html">{% trans "Terms and conditions" %}</a>
             </li>
             <li class="list-inline-item">
-              <a class="link-sm link-secondary" href="/#">مشاغل</a>
+              <a class="link-sm link-secondary" href="/#">{% trans "Careers" %}</a>
             </li>
           </ul>
           <!-- End List -->
@@ -313,7 +313,7 @@
                <div class="w-lg-75 mx-lg-auto">
                    <div class="d-flex justify-content-end mb-3">
                        <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas"
-                           aria-label="Close"></button>
+                           aria-label="{% trans 'Close' %}"></button>
                    </div>
 
                    <div class="mb-7">
@@ -322,10 +322,10 @@
                            <!-- Input Card -->
                            <div class="input-card">
                                <div class="input-card-form">
-                                   <input type="text" class="form-control form-control-lg" placeholder="جستجو محصولات"
-                                       name="q" aria-label="جستجو محصولات">
+                                   <input type="text" class="form-control form-control-lg" placeholder="{% trans 'Search products' %}"
+                                       name="q" aria-label="{% trans 'Search products' %}">
                                </div>
-                               <button type="submit" class="btn btn-primary btn-lg">جستجو کردن</button>
+                               <button type="submit" class="btn btn-primary btn-lg">{% trans "Search" %}</button>
                            </div>
                            <!-- End Input Card -->
                        </form>

--- a/core/templates/website/about.html
+++ b/core/templates/website/about.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static %}
+{% load static i18n %}
 
 {% block content %}
     <!-- Gallery -->
@@ -7,8 +7,8 @@
       <div class="w-lg-75 text-center mx-lg-auto">
         <!-- Heading -->
         <div class="mb-5 mb-md-10">
-          <h1 class="display-4">درباره ما</h1>
-          <p class="lead">Front یک شرکت وب است که وب سایت می سازد. کسب‌وکارها در هر اندازه‌ای - از استارت‌آپ‌های جدید گرفته تا شرکت‌های عمومی - از موضوع ما برای ایجاد و مدیریت آنلاین کسب‌وکارشان استفاده می‌کنند.</p>
+          <h1 class="display-4">{% trans "About us" %}</h1>
+          <p class="lead">{% blocktrans trimmed %}Front is a web company that builds websites. Businesses of every size—from new startups to public enterprises—use our theme to create and manage their online presence.{% endblocktrans %}</p>
         </div>
         <!-- End Heading -->
       </div>
@@ -56,7 +56,7 @@
         <div class="col-sm-4 col-lg-3 mb-7 mb-sm-0">
           <div class="text-center">
             <h2 class="display-4">7</h2>
-            <p class="small">سال در تجارت</p>
+            <p class="small">{% trans "Years in business" %}</p>
           </div>
         </div>
         <!-- End Col -->
@@ -64,7 +64,7 @@
         <div class="col-sm-4 col-lg-3 mb-7 mb-sm-0">
           <div class="text-center">
             <h2 class="display-4">3,5k+</h2>
-            <p class="small">نسخه های فروخته شده</p>
+            <p class="small">{% trans "Copies sold" %}</p>
           </div>
         </div>
         <!-- End Col -->
@@ -72,7 +72,7 @@
         <div class="col-sm-4 col-lg-3">
           <div class="text-center">
             <h2 class="display-4">85%</h2>
-            <p class="small">مشتریان خوشحال</p>
+            <p class="small">{% trans "Happy customers" %}</p>
           </div>
         </div>
         <!-- End Col -->
@@ -87,13 +87,13 @@
     <div class="container content-space-2 content-space-lg-3">
       <div class="row justify-content-lg-between">
         <div class="col-lg-4 mb-5 mb-lg-0">
-          <h2>ابزارها باید با کاربر سازگار شوند، نه برعکس.</h2>
+          <h2>{% trans "Tools should adapt to users, not the other way around." %}</h2>
         </div>
         <!-- End Col -->
 
         <div class="col-lg-6">
-          <p>از سال 2007، ما به 25 شرکت کمک کرده ایم تا بیش از 1000 محصول باورنکردنی را عرضه کنند. ما معتقدیم که بهترین راه حل های دیجیتال در تقاطع استراتژی کسب و کار، فناوری موجود و نیازهای واقعی کاربر ساخته می شوند.</p>
-          <p>همه چیز می تواند واقعاً پیچیده شود، واقعاً به سرعت، و یک چشم انداز عملی، مصنوعی و روشن ضروری است تا بتوان چیزی را ایجاد کرد که در نهایت قرار است مورد استفاده قرار گیرد. احساسات نیز نقش مهمی دارند و ایجاد زیبایی شناسی واضح و زیبا برای ایجاد محیطی دلپذیر که در آن کاربر واقعاً از زمانی که در آن سپری می‌کند لذت ببرد، از اهمیت بالایی برخوردار است. در نهایت، همه ما مشتاق چیزهای زیبایی هستیم که فقط کار می کنند</p>
+          <p>{% blocktrans trimmed %}Since 2007, we have helped 25 companies launch more than 1,000 remarkable products. We believe the best digital solutions are created where business strategy, existing technology, and genuine user needs intersect.{% endblocktrans %}</p>
+          <p>{% blocktrans trimmed %}Everything can become incredibly complex, incredibly fast, and a practical, tangible, and clear perspective is essential to build something that people will ultimately use. Emotion plays an important role, and crafting a clear, beautiful aesthetic that creates an enjoyable environment is vital. In the end, we all crave beautiful things that simply work.{% endblocktrans %}</p>
         </div>
         <!-- End Col -->
       </div>
@@ -107,8 +107,8 @@
     <div class="container content-space-2 content-space-lg-3">
       <!-- Heading -->
       <div class="w-md-75 w-lg-50 text-center mx-md-auto mb-5 mb-md-9">
-        <span class="text-cap">تیم ما</span>
-        <h2>ذهن های خلاق</h2>
+        <span class="text-cap">{% trans "Our team" %}</span>
+        <h2>{% trans "Creative minds" %}</h2>
       </div>
       <!-- End Heading -->
 
@@ -121,9 +121,9 @@
                 <img class="avatar-img" src="{% static '/img/160x160/img7.jpg' %}" alt="Image Description">
               </div>
 
-              <span class="card-subtitle">موسس / مدیر عامل</span>
-              <h4 class="card-title">کریستینا کری</h4>
-              <p class="card-text">من یک معتاد به کار جاه طلب هستم، اما جدای از آن، یک فرد بسیار ساده هستم.</p>
+              <span class="card-subtitle">{% trans "Founder / CEO" %}</span>
+              <h4 class="card-title">{% trans "Christina Kray" %}</h4>
+              <p class="card-text">{% trans "I'm an ambitious workaholic, but apart from that, a pretty simple person." %}</p>
             </div>
 
             <div class="card-footer pt-0">
@@ -160,9 +160,9 @@
                 <img class="avatar-img" src="{% static '/img/160x160/img3.jpg' %}" alt="Image Description">
               </div>
 
-              <span class="card-subtitle">مدیر پروژه</span>
-              <h4 class="card-title">جف فیشر</h4>
-              <p class="card-text">من یک معتاد به کار جاه طلب هستم، اما جدای از آن، یک فرد بسیار ساده هستم.</p>
+              <span class="card-subtitle">{% trans "Project manager" %}</span>
+              <h4 class="card-title">{% trans "Jeff Fisher" %}</h4>
+              <p class="card-text">{% trans "I'm an ambitious workaholic, but apart from that, a pretty simple person." %}</p>
             </div>
 
             <div class="card-footer pt-0">
@@ -199,9 +199,9 @@
                 <img class="avatar-img" src="{% static '/img/160x160/img10.jpg' %}" alt="Image Description">
               </div>
 
-              <span class="card-subtitle">طراح محصول</span>
-              <h4 class="card-title">امی فورن</h4>
-              <p class="card-text">من یک معتاد به کار جاه طلب هستم، اما جدای از آن، یک فرد بسیار ساده هستم.</p>
+              <span class="card-subtitle">{% trans "Product designer" %}</span>
+              <h4 class="card-title">{% trans "Amy Forney" %}</h4>
+              <p class="card-text">{% trans "I'm an ambitious workaholic, but apart from that, a pretty simple person." %}</p>
             </div>
 
             <div class="card-footer pt-0">
@@ -238,9 +238,9 @@
                 <img class="avatar-img" src="{% static '/img/160x160/img5.jpg' %}" alt="Image Description">
               </div>
 
-              <span class="card-subtitle">مشاور پشتیبانی</span>
-              <h4 class="card-title">فیلیپ ویلیامز</h4>
-              <p class="card-text">من یک معتاد به کار جاه طلب هستم، اما جدای از آن، یک فرد بسیار ساده هستم.</p>
+              <span class="card-subtitle">{% trans "Support consultant" %}</span>
+              <h4 class="card-title">{% trans "Philip Williams" %}</h4>
+              <p class="card-text">{% trans "I'm an ambitious workaholic, but apart from that, a pretty simple person." %}</p>
             </div>
 
             <div class="card-footer pt-0">
@@ -275,7 +275,7 @@
       <div class="text-center">
         <div class="card card-info-link card-sm">
           <div class="card-body">
-            میخواهی با ما کار کنی؟ <a class="card-link ms-2" href="./page-hire-us.html">استخدام می کنیم<span class="bi-chevron-left small me-1"></span></a>
+            {% trans "Want to work with us?" %} <a class="card-link ms-2" href="./page-hire-us.html">{% trans "We're hiring" %}<span class="bi-chevron-left small me-1"></span></a>
           </div>
         </div>
       </div>

--- a/core/templates/website/contact.html
+++ b/core/templates/website/contact.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
-{% load static %}
+{% load static i18n %}
 
 {% block content %}
         <!-- Hero -->
         <div class="position-relative bg-img-start" style="background-image: url(./assets/svg/components/card-11.svg);">
             <div class="container content-space-t-3 content-space-t-lg-5 content-space-b-2 position-relative zi-2">
                 <div class="w-md-75 w-lg-50 text-center mx-md-auto mb-5 mb-md-9">
-                    <h1>تماس با ما</h1>
-                    <p>نظرات و انتقادات خود را بیان کنین</p>
+                    <h1>{% trans "Contact us" %}</h1>
+                    <p>{% trans "Share your feedback and suggestions" %}</p>
                 </div>
 
                 <div class="row">
@@ -28,12 +28,12 @@
 
                                 </div>
 
-                                <h4 class="card-title">مشاوره خرید</h4>
-                                <p class="card-text text-body">دانش کافی در زمان خرید داشته باشید</p>
+                                <h4 class="card-title">{% trans "Purchase consultation" %}</h4>
+                                <p class="card-text text-body">{% trans "Gain the knowledge you need when making a purchase" %}</p>
                             </div>
 
                             <div class="card-footer pt-0">
-                                <span class="card-link">تماس با پشتیبانی <i
+                                <span class="card-link">{% trans "Contact support" %} <i
                                         class="bi-chevron-left small ms-1"></i></span>
                             </div>
                         </a>
@@ -58,12 +58,12 @@
 
                                 </div>
 
-                                <h4 class="card-title">سوالات متداول</h4>
-                                <p class="card-text text-body">سوالات خود را از ما بپرسید و پیدا کنین</p>
+                                <h4 class="card-title">{% trans "Frequently asked questions" %}</h4>
+                                <p class="card-text text-body">{% trans "Ask us anything and find the answers you need" %}</p>
                             </div>
 
                             <div class="card-footer pt-0">
-                                <span class="card-link">مشاهده سوالات<i class="bi-chevron-left small ms-1"></i></span>
+                                <span class="card-link">{% trans "View questions" %}<i class="bi-chevron-left small ms-1"></i></span>
                             </div>
                         </a>
                         <!-- End Card -->
@@ -87,12 +87,12 @@
 
                                 </div>
 
-                                <h4 class="card-title">کمک به توسعه</h4>
-                                <p class="card-text text-body">پیشنهادات سازنده خود را به توسعه دهندگان انتقال دهید</p>
+                                <h4 class="card-title">{% trans "Contribute to development" %}</h4>
+                                <p class="card-text text-body">{% trans "Share your constructive ideas with the developers" %}</p>
                             </div>
 
                             <div class="card-footer pt-0">
-                                <span class="card-link">تماس با پشتیبانی<i class="bi-chevron-left small ms-1"></i></span>
+                                <span class="card-link">{% trans "Contact support" %}<i class="bi-chevron-left small ms-1"></i></span>
                             </div>
                         </a>
                         <!-- End Card -->
@@ -120,8 +120,8 @@
                     <div class="card-body">
                         <!-- Heading -->
                         <div class="text-center mb-5 mb-md-9">
-                            <h2>فرم تماس با پشتیبانی</h2>
-                            <p>سوال یا نظرات خود را مطرح کنین</p>
+                            <h2>{% trans "Support contact form" %}</h2>
+                            <p>{% trans "Let us know your questions or comments" %}</p>
                         </div>
                         <!-- End Heading -->
 
@@ -132,10 +132,10 @@
                                 <div class="col-sm-6">
                                     <!-- Form -->
                                     <div class="mb-3">
-                                        <label class="form-label" for="hireUsFormFirstName">نام</label>
+                                        <label class="form-label" for="hireUsFormFirstName">{% trans "First name" %}</label>
                                         <input type="text" class="form-control form-control-lg"
                                             name="name" id="hireUsFormFirstName"
-                                            placeholder="نام" aria-label="First name">
+                                            placeholder="{% trans 'First name' %}" aria-label="{% trans 'First name' %}">
                                     </div>
                                     <!-- End Form -->
                                 </div>
@@ -144,10 +144,10 @@
                                 <div class="col-sm-6">
                                     <!-- Form -->
                                     <div class="mb-3">
-                                        <label class="form-label" for="hireUsFormLasttName">نام خانوادگی</label>
+                                        <label class="form-label" for="hireUsFormLasttName">{% trans "Last name" %}</label>
                                         <input type="text" class="form-control form-control-lg"
                                             name="last_name" id="hireUsFormLasttName"
-                                            placeholder="نام خانوادگی" aria-label="Last name">
+                                            placeholder="{% trans 'Last name' %}" aria-label="{% trans 'Last name' %}">
                                     </div>
                                     <!-- End Form -->
                                 </div>
@@ -159,10 +159,11 @@
                                 <div class="col-sm-6">
                                     <!-- Form -->
                                     <div class="mb-3">
-                                        <label class="form-label" for="hireUsFormWorkEmail">آدرس ایمیل</label>
+                                        <label class="form-label" for="hireUsFormWorkEmail">{% trans "Email address" %}</label>
                                         <input type="email" class="form-control form-control-lg"
                                             name="email" id="hireUsFormWorkEmail"
-                                            placeholder="email@site.com" aria-label="email@site.com">
+                                            placeholder="{% trans 'email@example.com' %}"
+                                            aria-label="{% trans 'Email address' %}">
                                     </div>
                                     <!-- End Form -->
                                 </div>
@@ -171,11 +172,12 @@
                                 <div class="col-sm-6">
                                     <!-- Form -->
                                     <div class="mb-3">
-                                        <label class="form-label" for="hireUsFormPhone">شماره همراه <span
-                                                class="form-label-secondary">(اختیاری)</span></label>
+                                        <label class="form-label" for="hireUsFormPhone">{% trans "Phone number" %} <span
+                                                class="form-label-secondary">{% trans "(optional)" %}</span></label>
                                         <input type="text" class="form-control form-control-lg"
                                             name="phone_number" id="hireUsFormPhone"
-                                            placeholder="+9891200000">
+                                            placeholder="{% trans '+1 (555) 000-0000' %}"
+                                            aria-label="{% trans 'Phone number' %}">
                                     </div>
                                     <!-- End Form -->
                                 </div>
@@ -185,19 +187,19 @@
 
                             <!-- Form -->
                             <div class="mb-3">
-                                <label class="form-label" for="hireUsFormDetails">توضیحات</label>
+                                <label class="form-label" for="hireUsFormDetails">{% trans "Details" %}</label>
                                 <textarea class="form-control form-control-lg" name="description"
-                                    id="hireUsFormDetails" placeholder="توضیحات خود را وارد نمایید"
-                                    aria-label="Tell us about your ..." rows="4"></textarea>
+                                    id="hireUsFormDetails" placeholder="{% trans 'Enter your message' %}"
+                                    aria-label="{% trans 'Tell us about your request' %}" rows="4"></textarea>
                             </div>
                             <!-- End Form -->
 
                             <div class="d-grid">
-                                <button type="submit" class="btn btn-primary btn-lg">ارسال درخواست</button>
+                                <button type="submit" class="btn btn-primary btn-lg">{% trans "Submit request" %}</button>
                             </div>
 
                             <div class="text-center">
-                                <p class="form-text">تیکت ها در اسرع وقت پاسخ داده خواهند شد</p>
+                                <p class="form-text">{% trans "We will respond to tickets as soon as possible" %}</p>
                             </div>
                         </form>
                         <!-- End Form -->

--- a/core/templates/website/index.html
+++ b/core/templates/website/index.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static %}
+{% load static i18n %}
 {% load shop_tags %}
 {% block content %}
 <!-- Hero -->
@@ -14,17 +14,14 @@
           <div class="row align-items-lg-center">
             <div class="col-lg-5 order-lg-2 mb-7 mb-lg-0">
               <div class="mb-6">
-                <h1 class="display-4 mb-4">درپوش طرح اصلی جلو</h1>
-                <p>
-                  فرانت علاوه بر اینکه در نوآوری‌های فنی بازی را تغییر می‌دهد،
-                  برخی از پرفروش‌ترین کلاه‌ها را در قفسه خود دارد.
-                </p>
+                <h1 class="display-4 mb-4">{% trans "Front classic cap" %}</h1>
+                <p>{% trans "Beyond changing the game with technical innovations, Front keeps some of the bestselling caps on its shelves." %}</p>
               </div>
 
               <div class="d-flex gap-2">
-                <a class="btn btn-primary rounded-pill" href="#"
-                  >نمایش جزئیات محصول</a
-                >
+                <a class="btn btn-primary rounded-pill" href="#">
+                  {% trans "View product details" %}
+                </a>
               </div>
             </div>
             <!-- End Col -->
@@ -53,18 +50,14 @@
           <div class="row align-items-lg-center">
             <div class="col-lg-5 order-lg-2 mb-7 mb-lg-0">
               <div class="mb-6">
-                <h2 class="display-4 mb-4">اپل آیپد پرو</h2>
-                <p>
-                  این همه جدید، تمام صفحه نمایش، و همه قدرتمند است. کاملاً
-                  بازطراحی شده و با پیشرفته‌ترین فن‌آوری ما بسته‌بندی شده است،
-                  شما را وادار می‌کند دوباره به توانایی iPad خود فکر کنید.
-                </p>
+                <h2 class="display-4 mb-4">{% trans "Apple iPad Pro" %}</h2>
+                <p>{% trans "All new, all screen, and all powerful. Completely redesigned and packed with our most advanced technology, it makes you rethink what your iPad can do." %}</p>
               </div>
 
               <div class="d-flex gap-2">
-                <a class="btn btn-primary rounded-pill" href="#"
-                  >نمایش جزئیات محصول</a
-                >
+                <a class="btn btn-primary rounded-pill" href="#">
+                  {% trans "View product details" %}
+                </a>
               </div>
             </div>
             <!-- End Col -->
@@ -93,19 +86,14 @@
           <div class="row align-items-lg-center">
             <div class="col-lg-5 order-lg-2 mb-7 mb-lg-0">
               <div class="mb-6">
-                <h3 class="display-4 mb-4">هودی سلیو</h3>
-                <p>
-                  لیبل فرانسوی Celio که در سال 1985 تأسیس شد، 30 سال تخصص را در
-                  محدوده لباس‌های مردانه معاصر خود قرار می‌دهد. با شلوارک جین،
-                  شلوار چینی و پیراهن های چاپ شده، انتظار سبک پروازی را برای یک
-                  شهر یا ساحل داشته باشید.
-                </p>
+                <h3 class="display-4 mb-4">{% trans "Sleeve hoodie" %}</h3>
+                <p>{% trans "Founded in 1985, the French label Celio brings 30 years of expertise to its modern menswear range. Pair with denim shorts, chinos, and printed shirts for city or seaside style." %}</p>
               </div>
 
               <div class="d-flex gap-2">
-                <a class="btn btn-primary rounded-pill" href="#"
-                  >نمایش جزئیات محصول</a
-                >
+                <a class="btn btn-primary rounded-pill" href="#">
+                  {% trans "View product details" %}
+                </a>
               </div>
             </div>
             <!-- End Col -->
@@ -211,8 +199,8 @@
             />
           </div>
           <div class="flex-grow-1 ms-4">
-            <h4 class="mb-1">تسویه حساب ایمن</h4>
-            <p class="small mb-0">تسویه حساب مطمئن تضمینی</p>
+            <h4 class="mb-1">{% trans "Secure checkout" %}</h4>
+            <p class="small mb-0">{% trans "Guaranteed safe payment" %}</p>
           </div>
         </div>
         <!-- End Icon Block -->
@@ -230,10 +218,8 @@
             />
           </div>
           <div class="flex-grow-1 ms-4">
-            <h4 class="mb-1">30 روز بازگشت</h4>
-            <p class="small mb-0">
-              پیشنهاد ما به شما بازپرداخت کامل ظرف 30 روز پس از خرید است.
-            </p>
+            <h4 class="mb-1">{% trans "30-day returns" %}</h4>
+            <p class="small mb-0">{% trans "Enjoy a full refund within 30 days of purchase." %}</p>
           </div>
         </div>
         <!-- End Icon Block -->
@@ -251,11 +237,8 @@
             />
           </div>
           <div class="flex-grow-1 ms-4">
-            <h4 class="mb-1">ارسال رایگان</h4>
-            <p class="small mb-0">
-              حمل و نقل استاندارد رایگان را به صورت خودکار در هر سفارش دریافت
-              کنید.
-            </p>
+            <h4 class="mb-1">{% trans "Free shipping" %}</h4>
+            <p class="small mb-0">{% trans "Automatically receive standard shipping at no extra cost on every order." %}</p>
           </div>
         </div>
         <!-- End Icon Block -->
@@ -271,7 +254,7 @@
 <div class="container content-space-2 content-space-lg-3">
   <!-- Heading -->
   <div class="w-md-75 w-lg-50 text-center mx-md-auto mb-5 mb-md-9">
-    <h2>خرید بهترین محصولات در فروشگاه</h2>
+    <h2>{% trans "Shop the best products in store" %}</h2>
   </div>
   <!-- End Heading -->
   <div class="row mb-2">
@@ -283,7 +266,7 @@
   <!-- End Row -->
 
   <div class="text-center">
-    <p class="small">فروش ویژه محصولات برای مدت زمانی محدود</p>
+    <p class="small">{% trans "Limited-time special offers on featured products" %}</p>
   </div>
 </div>
 <!-- End Card Grid -->
@@ -301,8 +284,8 @@
         "
       >
         <div class="card-body">
-          <span class="card-subtitle text-danger">فقط برای زمانی محدود</span>
-          <h2 class="card-title display-4">70% تخفیف</h2>
+          <span class="card-subtitle text-danger">{% trans "Limited time only" %}</span>
+          <h2 class="card-title display-4">{% trans "70% off" %}</h2>
 
           <div class="w-md-65">
             <!-- Countdown -->
@@ -312,7 +295,7 @@
                   <span class="js-cd-days h2"></span>
                 </div>
 
-                <h5 class="card-title">روزها</h5>
+                <h5 class="card-title">{% trans "Days" %}</h5>
               </div>
               <!-- End Col -->
 
@@ -321,7 +304,7 @@
                   <span class="js-cd-hours h2"></span>
                 </div>
 
-                <h5 class="card-title">ساعت ها</h5>
+                <h5 class="card-title">{% trans "Hours" %}</h5>
               </div>
               <!-- End Col -->
 
@@ -330,7 +313,7 @@
                   <span class="js-cd-minutes h2"></span>
                 </div>
 
-                <h5 class="card-title">دقیقه</h5>
+                <h5 class="card-title">{% trans "Minutes" %}</h5>
               </div>
               <!-- End Col -->
 
@@ -339,7 +322,7 @@
                   <span class="js-cd-seconds h2"></span>
                 </div>
 
-                <h5 class="card-title">ثانیه</h5>
+                <h5 class="card-title">{% trans "Seconds" %}</h5>
               </div>
               <!-- End Col -->
             </div>
@@ -349,7 +332,7 @@
           <a
             class="btn btn-light btn-sm btn-transition rounded-pill px-6"
             href="#"
-            >خرید کنید</a
+            >{% trans "Shop now" %}</a
           >
         </div>
       </div>
@@ -368,17 +351,14 @@
         <div class="card-body">
           <div class="mb-4">
             <h2 class="card-title text-white">$109.99</h2>
-            <h3 class="card-title text-white">دوچرخه Nakto 26</h3>
-            <p class="card-text text-white">
-              دوچرخه های NAKTO برای نجات محیط زیست و به ارمغان آوردن سرگرمی برای
-              دوستانمان!
-            </p>
+            <h3 class="card-title text-white">{% trans "Nakto 26 Bike" %}</h3>
+            <p class="card-text text-white">{% trans "NAKTO bikes are built to protect the environment and bring fun to our friends!" %}</p>
           </div>
 
           <a
             class="btn btn-light btn-sm btn-transition rounded-pill px-6"
             href="#"
-            >خرید کنید</a
+            >{% trans "Shop now" %}</a
           >
         </div>
       </div>
@@ -397,8 +377,8 @@
       <div class="row justify-content-lg-between">
         <!-- Heading -->
         <div class="mb-5">
-          <span class="text-cap">ثبت نام</span>
-          <h2>اخبار جدید را دریافت کنید</h2>
+          <span class="text-cap">{% trans "Sign up" %}</span>
+          <h2>{% trans "Get the latest news" %}</h2>
         </div>
         <!-- End Heading -->
 
@@ -406,27 +386,25 @@
           <!-- Input Card -->
           <div class="input-card input-card-pill input-card-sm border mb-3">
             <div class="input-card-form">
-              <label for="subscribeForm" class="form-label visually-hidden"
-                >ایمیل را وارد کنید</label
-              >
+              <label for="subscribeForm" class="form-label visually-hidden">{% trans "Enter your email" %}</label>
               <input
                 type="text"
                 class="form-control form-control-lg"
                 id="subscribeForm"
-                placeholder="ایمیل خود را وارد نمایید"
-                aria-label="ایمیل خود را وارد کنید"
+                placeholder="{% trans 'Enter your email address' %}"
+                aria-label="{% trans 'Enter your email' %}"
               />
             </div>
             <button type="button" class="btn btn-primary btn-lg rounded-pill">
-              ثبت نام
+              {% trans "Subscribe" %}
             </button>
           </div>
           <!-- End Input Card -->
         </form>
 
         <p class="small">
-          می توانید در هر زمانی اشتراک خود را لغو کنید
-          <a href="#">سیاست حفظ حریم خصوصی</a> ما را بخوانید
+          {% trans "You can unsubscribe at any time" %}
+          <a href="#">{% trans "Read our privacy policy" %}</a>
         </p>
       </div>
     </div>

--- a/core/website/views.py
+++ b/core/website/views.py
@@ -1,6 +1,7 @@
 from django.contrib import messages
 from django.shortcuts import redirect
-from django.views.generic import TemplateView, CreateView
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import CreateView, TemplateView
 from django.contrib.messages.views import SuccessMessageMixin
 from dashboard.models import TicketModel
 
@@ -18,11 +19,11 @@ class ContactView(CreateView, SuccessMessageMixin):
     model = TicketModel
     fields = "__all__"
     success_url = "/contact/"
-    success_message = "تیکت شما با موفقیت ارسال شد"
+    success_message = _("Your ticket was sent successfully")
 
     error_messages = {
         "name": {
-            "required": "فیلد اسم اجباری است",
+            "required": _("The name field is required."),
         },
     }
 


### PR DESCRIPTION
## Summary
- translate the shared base layout and public website pages to English and wrap strings in Django translation tags
- update the 404 error template to English and localize its text content
- convert backend status labels and flash messages to English while using gettext for future localization
- localize contact form placeholders and accessibility labels so helper text is covered by translation tags

## Testing
- python core/manage.py check *(fails: ModuleNotFoundError: No module named 'decouple')*

------
https://chatgpt.com/codex/tasks/task_e_68e44dfdc4888320999ed6f11fd8218c