### PR TITLE
Complete authentication and wishlist flows

### DIFF
--- a/core/accounts/views.py
+++ b/core/accounts/views.py
@@ -1,5 +1,7 @@
+from django.contrib import messages
 from django.contrib.auth import login, views as auth_views
 from django.contrib.messages.views import SuccessMessageMixin
+from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import CreateView
 
@@ -10,7 +12,7 @@ class SignUpView(SuccessMessageMixin, CreateView):
     template_name = "accounts/signup.html"
     form_class = RegistrationForm
     success_message = _("User registration completed successfully")
-    success_url = "/"
+    success_url = reverse_lazy("website:home")
 
     def form_valid(self, form):
         response = super().form_valid(form)
@@ -27,4 +29,9 @@ class LoginView(SuccessMessageMixin, auth_views.LoginView):
 
 
 class LogoutView(auth_views.LogoutView):
-    pass
+    next_page = reverse_lazy("website:home")
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.is_authenticated:
+            messages.success(request, _("Signed out successfully"))
+        return super().dispatch(request, *args, **kwargs)

--- a/core/dashboard/admin/forms/profile.py
+++ b/core/dashboard/admin/forms/profile.py
@@ -6,7 +6,29 @@ from accounts.models import Profile
 
 
 class ChangePassForm(PasswordChangeForm):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["old_password"].widget.attrs.update(
+            {
+                "class": "form-control",
+                "placeholder": _("Enter your current password"),
+                "autocomplete": "current-password",
+            }
+        )
+        self.fields["new_password1"].widget.attrs.update(
+            {
+                "class": "form-control",
+                "placeholder": _("Enter a new password"),
+                "autocomplete": "new-password",
+            }
+        )
+        self.fields["new_password2"].widget.attrs.update(
+            {
+                "class": "form-control",
+                "placeholder": _("Confirm the new password"),
+                "autocomplete": "new-password",
+            }
+        )
 
 
 class ProfileForm(forms.ModelForm):

--- a/core/dashboard/customer/forms/profile.py
+++ b/core/dashboard/customer/forms/profile.py
@@ -6,7 +6,29 @@ from accounts.models import Profile
 
 
 class ChangePassForm(PasswordChangeForm):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["old_password"].widget.attrs.update(
+            {
+                "class": "form-control",
+                "placeholder": _("Enter your current password"),
+                "autocomplete": "current-password",
+            }
+        )
+        self.fields["new_password1"].widget.attrs.update(
+            {
+                "class": "form-control",
+                "placeholder": _("Enter a new password"),
+                "autocomplete": "new-password",
+            }
+        )
+        self.fields["new_password2"].widget.attrs.update(
+            {
+                "class": "form-control",
+                "placeholder": _("Confirm the new password"),
+                "autocomplete": "new-password",
+            }
+        )
 
 
 class ProfileForm(forms.ModelForm):

--- a/core/dashboard/customer/views/profile.py
+++ b/core/dashboard/customer/views/profile.py
@@ -5,7 +5,7 @@ from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView, UpdateView
 
-from accounts.models import User
+from accounts.models import Profile, User
 
 from ...permissions import CustomerPermissions
 from ..forms import *

--- a/core/shop/views.py
+++ b/core/shop/views.py
@@ -2,12 +2,11 @@ from django.views import generic
 from django.core.exceptions import FieldError
 from django.db.models import Count, Q
 from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
-from django.views import generic
 from django.views.decorators.cache import cache_page
 
-from cart.cart import CartSession
 from review.models import ReviewModel
 
 from .models import CategoryModel, ProductModel, ProductStatus, WishListModel
@@ -96,7 +95,7 @@ class ShopProductListView(generic.ListView):
 
 
 # @method_decorator(cache_page(60 * 15), name="dispatch")
-class ShopProductDetailView(generic.DeleteView):
+class ShopProductDetailView(generic.DetailView):
     template_name = "shop/product_detail.html"
     queryset = ProductModel.objects.filter(status=ProductStatus.active.value)
 
@@ -121,13 +120,29 @@ class ShopProductDetailView(generic.DeleteView):
 
 class AddOrRemoveWish(generic.View):
     def post(self, request, *args, **kwargs):
-        product_id = request.POST.get("product_id")
-        if product_id:
-            wish_obj, created = WishListModel.objects.get_or_create(
-                user=request.user, product_id=product_id
+        if not request.user.is_authenticated:
+            return JsonResponse(
+                {"message": _("Authentication required")}, status=401
             )
+
+        product_id = request.POST.get("product_id")
+        if not product_id:
+            return JsonResponse(
+                {"message": _("Product identifier is required")}, status=400
+            )
+
+        product = get_object_or_404(
+            ProductModel,
+            pk=product_id,
+            status=ProductStatus.active.value,
+        )
+
+        wish_obj, created = WishListModel.objects.get_or_create(
+            user=request.user, product=product
+        )
+        if created:
             message = _("Product added to wishlist")
-            if not created:
-                wish_obj.delete()
-                message = _("Product removed from wishlist")
+        else:
+            wish_obj.delete()
+            message = _("Product removed from wishlist")
         return JsonResponse({"message": message})


### PR DESCRIPTION
## Summary
- send users home after signup/logout and display a confirmation message when logging out
- style the admin and customer dashboard password change forms with consistent widgets
- fix customer profile imports and harden wishlist toggling and product detail views

## Testing
- python core/manage.py check *(fails: ModuleNotFoundError: No module named 'decouple')*

------
https://chatgpt.com/codex/tasks/task_e_68e53a5e2c108320824efa48d4bfdbc5