### PR TITLE
Rename site branding to Felio Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<h1 align="center">Django Online Shop</h1>
+<h1 align="center">Felio Design</h1>
 </div>
 <p align="center">
 <a href="https://www.python.org" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/> </a>

--- a/core/core/urls.py
+++ b/core/core/urls.py
@@ -39,7 +39,7 @@ if settings.DEBUG:
 
     schema_view = get_schema_view(
         openapi.Info(
-            title="Django Online Shop API",
+            title="Felio Design API",
             default_version="v1",
             description="you can use it by any front end framework like (React, Vue, Angular, ...)",
             terms_of_service="https://www.google.com/policies/terms/",

--- a/core/templates/404.html
+++ b/core/templates/404.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
   <!-- Title -->
-  <title>{% trans "Error 404 | Front - Responsive Multipurpose Template" %}</title>
+  <title>{% trans "Error 404 | Felio Design - Responsive Multipurpose Template" %}</title>
 
   <!-- Font -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
@@ -17,7 +17,7 @@
   <link rel="stylesheet" href="{% static 'css/vendor.min.css' %}">
   <link rel="stylesheet" href="{% static 'vendor/bootstrap-icons/font/bootstrap-icons.css' %}">
 
-  <!-- CSS Front Template -->
+  <!-- CSS Felio Design Template -->
   <link rel="stylesheet" href="{% static 'css/theme.min.css' %}?v=1.0">
 </head>
 
@@ -27,7 +27,7 @@
     <div class="container">
       <nav class="navbar-nav-wrap">
         <!-- Default Logo -->
-        <a class="navbar-brand" href="{% url 'website:home' %}" aria-label="Front">
+        <a class="navbar-brand" href="{% url 'website:home' %}" aria-label="Felio Design">
           <img class="navbar-brand-logo" src="{% static 'svg/logos/logo.svg' %}" alt="Logo">
         </a>
         <!-- End Default Logo -->
@@ -60,7 +60,7 @@
     <div class="container pb-5 content-space-b-sm-1">
       <div class="row justify-content-between align-items-center">
         <div class="col-sm mb-3 mb-sm-0">
-          <p class="small mb-0">&copy; {% trans "Front. Htmlstream 2021." %}</p>
+          <p class="small mb-0">&copy; {% trans "Felio Design. Htmlstream 2021." %}</p>
         </div>
 
         <div class="col-sm-auto">
@@ -97,7 +97,7 @@
   </footer>
   <!-- ========== END FOOTER ========== -->
 
-  <!-- JS Front -->
+  <!-- JS Felio Design -->
   <script src="{% static 'js/theme.min.js' %}"></script>
 </body>
 </html>

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -18,7 +18,7 @@
   <link rel="stylesheet" href="{% static 'css/vendor.min.css' %}">
   <link rel="stylesheet" href="{% static 'vendor/bootstrap-icons/font/bootstrap-icons.css' %}">
 
-  <!-- CSS Front Template -->
+  <!-- CSS Felio Design Template -->
   <link rel="stylesheet" href="{% static 'css/theme.min.css' %}?v=1.0">
 
 <!-- CSS Toastify -->
@@ -32,7 +32,7 @@
       <div class="container">
         <nav class="js-mega-menu navbar-nav-wrap">
           <!-- Default Logo -->
-          <a class="navbar-brand" href="{% url 'website:home' %}" aria-label="Front">
+          <a class="navbar-brand" href="{% url 'website:home' %}" aria-label="Felio Design">
             <img class="navbar-brand-logo" src="{% static 'svg/logos/logo.svg' %}" alt="Logo">
           </a>
           <!-- End Default Logo -->
@@ -116,12 +116,12 @@
         <div class="col-lg-3 mb-5">
           <div class="d-flex align-items-start flex-column h-100">
             <!-- Logo -->
-            <a class="w-100 mb-3 mb-lg-auto" href="{% url 'website:home' %}" aria-label="Front">
+            <a class="w-100 mb-3 mb-lg-auto" href="{% url 'website:home' %}" aria-label="Felio Design">
               <img class="brand" src="{% static 'svg/logos/logo.svg' %}" alt="Logo">
             </a>
             <!-- End Logo -->
 
-            <p class="text-muted small mb-0">&copy; {% trans "Benyamin 2023 Front RTL" %}</p>
+            <p class="text-muted small mb-0">&copy; {% trans "Benyamin 2023 Felio Design RTL" %}</p>
           </div>
         </div>
 
@@ -346,7 +346,7 @@
   <!-- JS Implementing Plugins -->
   <script src="{% static 'js/vendor.min.js' %}"></script>
 
-  <!-- JS Front -->
+  <!-- JS Felio Design -->
   <script src="{% static 'js/theme.min.js' %}"></script>
 <!-- JS Toastify -->
   <script src="{% static 'vendor/toastify/toastify.js' %}"></script>

--- a/core/templates/cart/cart.html
+++ b/core/templates/cart/cart.html
@@ -199,7 +199,7 @@
 <!-- JS Implementing Plugins -->
 <script src="{% static '/js/vendor.min.js' %}"></script>
 
-<!-- JS Front -->
+<!-- JS Felio Design -->
 <script src="{% static '/js/theme.min.js' %}"></script>
 
 <!-- JS Plugins Init. -->

--- a/core/templates/dashboard/admin/base.html
+++ b/core/templates/dashboard/admin/base.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="{% static 'css/vendor.min.css' %}">
     <link rel="stylesheet" href="{% static 'vendor/bootstrap-icons/font/bootstrap-icons.css' %}">
 
-    <!-- CSS Front Template -->
+    <!-- CSS Felio Design Template -->
     <link rel="stylesheet" href="{% static 'css/theme.min.css' %}">
     <link rel="stylesheet" href="{% static 'vendor/toastify/toastify.css' %}">
 
@@ -41,7 +41,7 @@
         <div class="container">
             <nav class="js-mega-menu navbar-nav-wrap">
                 <!-- Default Logo -->
-                <a class="navbar-brand" href="{% url 'website:home' %}" aria-label="Front">
+                <a class="navbar-brand" href="{% url 'website:home' %}" aria-label="Felio Design">
                     <img class="navbar-brand-logo" src="{% static 'svg/logos/logo.svg' %}" alt="Logo">
                 </a>
                 <!-- End Default Logo -->
@@ -205,12 +205,12 @@
                 <div class="col-lg-3 mb-5">
                     <div class="d-flex align-items-start flex-column h-100">
                         <!-- Logo -->
-                        <a class="w-100 mb-3 mb-lg-auto" href="{% url 'website:home' %}" aria-label="Front">
+                        <a class="w-100 mb-3 mb-lg-auto" href="{% url 'website:home' %}" aria-label="Felio Design">
                             <img class="brand" src="{% static 'svg/logos/logo.svg' %}" alt="Logo">
                         </a>
                         <!-- End Logo -->
 
-                        <p class="text-muted small mb-0">&copy; Maryam Farajian 2023 Front RTL</p>
+                        <p class="text-muted small mb-0">&copy; Maryam Farajian 2023 Felio Design RTL</p>
                     </div>
                 </div>
 
@@ -416,7 +416,7 @@
   <!-- JS Implementing Plugins -->
   <script src="{% static 'js/vendor.min.js' %}"></script>
 
-  <!-- JS Front -->
+  <!-- JS Felio Design -->
   <script src="{% static 'js/theme.min.js' %}"></script>
 <!-- JS Toastify -->
   <script src="{% static 'vendor/toastify/toastify.js' %}"></script>

--- a/core/templates/dashboard/admin/profile/change-pass.html
+++ b/core/templates/dashboard/admin/profile/change-pass.html
@@ -79,7 +79,7 @@
 
     <!-- Body -->
     <div class="card-body">
-        <p class="card-text">{% trans "The integrated features of these accounts make it easier to collaborate with the people you know in Front." %}</p>
+        <p class="card-text">{% trans "The integrated features of these accounts make it easier to collaborate with the people you know in Felio Design." %}</p>
 
         <!-- Form -->
         <form>

--- a/core/templates/dashboard/customer/base.html
+++ b/core/templates/dashboard/customer/base.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="{% static 'css/vendor.min.css' %}">
     <link rel="stylesheet" href="{% static 'vendor/bootstrap-icons/font/bootstrap-icons.css' %}">
 
-    <!-- CSS Front Template -->
+    <!-- CSS Felio Design Template -->
     <link rel="stylesheet" href="{% static 'css/theme.min.css' %}">
     <link rel="stylesheet" href="{% static 'vendor/toastify/toastify.css' %}">
 
@@ -41,7 +41,7 @@
         <div class="container">
             <nav class="js-mega-menu navbar-nav-wrap">
                 <!-- Default Logo -->
-                <a class="navbar-brand" href="{% url 'website:home' %}" aria-label="Front">
+                <a class="navbar-brand" href="{% url 'website:home' %}" aria-label="Felio Design">
                     <img class="navbar-brand-logo" src="{% static 'svg/logos/logo.svg' %}" alt="Logo">
                 </a>
                 <!-- End Default Logo -->
@@ -205,12 +205,12 @@
                 <div class="col-lg-3 mb-5">
                     <div class="d-flex align-items-start flex-column h-100">
                         <!-- Logo -->
-                        <a class="w-100 mb-3 mb-lg-auto" href="{% url 'website:home' %}" aria-label="Front">
+                        <a class="w-100 mb-3 mb-lg-auto" href="{% url 'website:home' %}" aria-label="Felio Design">
                             <img class="brand" src="{% static 'svg/logos/logo.svg' %}" alt="Logo">
                         </a>
                         <!-- End Logo -->
 
-                        <p class="text-muted small mb-0">&copy; {% trans "Maryam Farajian 2023 Front RTL" %}</p>
+                        <p class="text-muted small mb-0">&copy; {% trans "Maryam Farajian 2023 Felio Design RTL" %}</p>
                     </div>
                 </div>
 
@@ -416,7 +416,7 @@
   <!-- JS Implementing Plugins -->
   <script src="{% static 'js/vendor.min.js' %}"></script>
 
-  <!-- JS Front -->
+  <!-- JS Felio Design -->
   <script src="{% static 'js/theme.min.js' %}"></script>
 <!-- JS Toastify -->
   <script src="{% static 'vendor/toastify/toastify.js' %}"></script>

--- a/core/templates/dashboard/customer/orders/order-invoice.html
+++ b/core/templates/dashboard/customer/orders/order-invoice.html
@@ -20,7 +20,7 @@
   <link rel="stylesheet" href="{% static 'css/vendor.min.css' %}">
   <link rel="stylesheet" href="{% static 'vendor/bootstrap-icons/font/bootstrap-icons.css' %}">
 
-  <!-- CSS Front Template -->
+  <!-- CSS Felio Design Template -->
   <link rel="stylesheet" href="{% static 'css/theme.min.css' %}?v=1.0">
 </head>
 
@@ -50,7 +50,7 @@
                   <img class="avatar" src="{% static 'svg/logos/logo-short.svg' %}" alt="Logo">
                 </div>
 
-                <h1 class="h2 text-primary">{% trans "Front Inc." %}</h1>
+                <h1 class="h2 text-primary">{% trans "Felio Design Inc." %}</h1>
               </div>
               <!-- End Col -->
 
@@ -141,7 +141,7 @@
   </main>
   <!-- ========== END MAIN CONTENT ========== -->
 
-  <!-- JS Front -->
+  <!-- JS Felio Design -->
   <script src="{% static 'js/theme.min.js' %}"></script>
 </body>
 

--- a/core/templates/dashboard/customer/profile/change-pass.html
+++ b/core/templates/dashboard/customer/profile/change-pass.html
@@ -79,7 +79,7 @@
 
     <!-- Body -->
     <div class="card-body">
-        <p class="card-text">{% trans "The integrated features of these accounts make it easier to collaborate with the people you know in Front." %}</p>
+        <p class="card-text">{% trans "The integrated features of these accounts make it easier to collaborate with the people you know in Felio Design." %}</p>
 
         <!-- Form -->
         <form>

--- a/core/templates/website/about.html
+++ b/core/templates/website/about.html
@@ -8,7 +8,7 @@
         <!-- Heading -->
         <div class="mb-5 mb-md-10">
           <h1 class="display-4">{% trans "About us" %}</h1>
-          <p class="lead">{% blocktrans trimmed %}Front is a web company that builds websites. Businesses of every size—from new startups to public enterprises—use our theme to create and manage their online presence.{% endblocktrans %}</p>
+          <p class="lead">{% blocktrans trimmed %}Felio Design is a web company that builds websites. Businesses of every size—from new startups to public enterprises—use our theme to create and manage their online presence.{% endblocktrans %}</p>
         </div>
         <!-- End Heading -->
       </div>

--- a/core/templates/website/index.html
+++ b/core/templates/website/index.html
@@ -14,8 +14,8 @@
           <div class="row align-items-lg-center">
             <div class="col-lg-5 order-lg-2 mb-7 mb-lg-0">
               <div class="mb-6">
-                <h1 class="display-4 mb-4">{% trans "Front classic cap" %}</h1>
-                <p>{% trans "Beyond changing the game with technical innovations, Front keeps some of the bestselling caps on its shelves." %}</p>
+                <h1 class="display-4 mb-4">{% trans "Felio Design classic cap" %}</h1>
+                <p>{% trans "Beyond changing the game with technical innovations, Felio Design keeps some of the bestselling caps on its shelves." %}</p>
               </div>
 
               <div class="d-flex gap-2">


### PR DESCRIPTION
## Summary
- update the public templates to reference the new Felio Design name in headers, footers, and copy
- rename supporting documentation and API schema metadata to Felio Design

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e63f7a20f08320b7cdf6d9c4e795cf