### PR TITLE
Normalize numerals across UI

### DIFF
--- a/core/static/js/latin-digits.js
+++ b/core/static/js/latin-digits.js
@@ -1,0 +1,128 @@
+(function () {
+  const digitMap = {
+    '\u0660': '0',
+    '\u0661': '1',
+    '\u0662': '2',
+    '\u0663': '3',
+    '\u0664': '4',
+    '\u0665': '5',
+    '\u0666': '6',
+    '\u0667': '7',
+    '\u0668': '8',
+    '\u0669': '9',
+    '\u06F0': '0',
+    '\u06F1': '1',
+    '\u06F2': '2',
+    '\u06F3': '3',
+    '\u06F4': '4',
+    '\u06F5': '5',
+    '\u06F6': '6',
+    '\u06F7': '7',
+    '\u06F8': '8',
+    '\u06F9': '9'
+  };
+
+  const digitPattern = /[\u0660-\u0669\u06F0-\u06F9]/g;
+
+  function convertDigits(value) {
+    if (!value || typeof value !== 'string') {
+      return value;
+    }
+    return value.replace(digitPattern, (char) => digitMap[char] || char);
+  }
+
+  function shouldSkipElement(element) {
+    if (!(element instanceof Element)) {
+      return true;
+    }
+
+    const tagName = element.tagName;
+    return tagName === 'SCRIPT' || tagName === 'STYLE' || tagName === 'CODE' || tagName === 'PRE';
+  }
+
+  function convertTextNodes(node) {
+    if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+      node.childNodes.forEach(convertTextNodes);
+      return;
+    }
+
+    if (node.nodeType === Node.TEXT_NODE) {
+      const newValue = convertDigits(node.textContent);
+      if (newValue !== node.textContent) {
+        node.textContent = newValue;
+      }
+      return;
+    }
+
+    if (node.nodeType === Node.ELEMENT_NODE && !shouldSkipElement(node)) {
+      const element = node;
+
+      if (element.childNodes.length) {
+        element.childNodes.forEach(convertTextNodes);
+      }
+
+      if ('value' in element && typeof element.value === 'string') {
+        const updatedValue = convertDigits(element.value);
+        if (updatedValue !== element.value) {
+          element.value = updatedValue;
+        }
+      }
+
+      if (element.hasAttribute && element.hasAttribute('placeholder')) {
+        const placeholder = element.getAttribute('placeholder');
+        const updatedPlaceholder = convertDigits(placeholder);
+        if (updatedPlaceholder !== placeholder) {
+          element.setAttribute('placeholder', updatedPlaceholder);
+        }
+      }
+
+      Array.from(element.attributes || []).forEach((attr) => {
+        if (!attr.value) {
+          return;
+        }
+        const updated = convertDigits(attr.value);
+        if (updated !== attr.value) {
+          element.setAttribute(attr.name, updated);
+        }
+      });
+    }
+  }
+
+  function handleMutations(mutations) {
+    mutations.forEach((mutation) => {
+      if (mutation.type === 'characterData' && mutation.target.nodeType === Node.TEXT_NODE) {
+        convertTextNodes(mutation.target);
+      }
+
+      if (mutation.type === 'childList') {
+        mutation.addedNodes.forEach((node) => {
+          if (node.nodeType === Node.TEXT_NODE || node.nodeType === Node.ELEMENT_NODE) {
+            convertTextNodes(node);
+          }
+        });
+      }
+
+      if (mutation.type === 'attributes' && mutation.target.nodeType === Node.ELEMENT_NODE) {
+        convertTextNodes(mutation.target);
+      }
+    });
+  }
+
+  function initializeDigitConversion() {
+    convertTextNodes(document.body);
+
+    const observer = new MutationObserver(handleMutations);
+    observer.observe(document.body, {
+      characterData: true,
+      subtree: true,
+      childList: true,
+      attributes: true
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeDigitConversion);
+  } else {
+    initializeDigitConversion();
+  }
+})();

--- a/core/templates/404.html
+++ b/core/templates/404.html
@@ -97,6 +97,9 @@
   </footer>
   <!-- ========== END FOOTER ========== -->
 
+  <!-- JS Digit Normalizer -->
+  <script src="{% static 'js/latin-digits.js' %}"></script>
+
   <!-- JS Felio Design -->
   <script src="{% static 'js/theme.min.js' %}"></script>
 </body>

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -346,6 +346,9 @@
   <!-- JS Implementing Plugins -->
   <script src="{% static 'js/vendor.min.js' %}"></script>
 
+  <!-- JS Digit Normalizer -->
+  <script src="{% static 'js/latin-digits.js' %}"></script>
+
   <!-- JS Felio Design -->
   <script src="{% static 'js/theme.min.js' %}"></script>
 <!-- JS Toastify -->

--- a/core/templates/cart/cart.html
+++ b/core/templates/cart/cart.html
@@ -199,6 +199,9 @@
 <!-- JS Implementing Plugins -->
 <script src="{% static '/js/vendor.min.js' %}"></script>
 
+<!-- JS Digit Normalizer -->
+<script src="{% static '/js/latin-digits.js' %}"></script>
+
 <!-- JS Felio Design -->
 <script src="{% static '/js/theme.min.js' %}"></script>
 

--- a/core/templates/dashboard/admin/base.html
+++ b/core/templates/dashboard/admin/base.html
@@ -416,6 +416,9 @@
   <!-- JS Implementing Plugins -->
   <script src="{% static 'js/vendor.min.js' %}"></script>
 
+  <!-- JS Digit Normalizer -->
+  <script src="{% static 'js/latin-digits.js' %}"></script>
+
   <!-- JS Felio Design -->
   <script src="{% static 'js/theme.min.js' %}"></script>
 <!-- JS Toastify -->

--- a/core/templates/dashboard/customer/base.html
+++ b/core/templates/dashboard/customer/base.html
@@ -416,6 +416,9 @@
   <!-- JS Implementing Plugins -->
   <script src="{% static 'js/vendor.min.js' %}"></script>
 
+  <!-- JS Digit Normalizer -->
+  <script src="{% static 'js/latin-digits.js' %}"></script>
+
   <!-- JS Felio Design -->
   <script src="{% static 'js/theme.min.js' %}"></script>
 <!-- JS Toastify -->

--- a/core/templates/dashboard/customer/orders/order-invoice.html
+++ b/core/templates/dashboard/customer/orders/order-invoice.html
@@ -141,6 +141,9 @@
   </main>
   <!-- ========== END MAIN CONTENT ========== -->
 
+  <!-- JS Digit Normalizer -->
+  <script src="{% static 'js/latin-digits.js' %}"></script>
+
   <!-- JS Felio Design -->
   <script src="{% static 'js/theme.min.js' %}"></script>
 </body>

--- a/core/templates/order/checkout.html
+++ b/core/templates/order/checkout.html
@@ -136,7 +136,7 @@
       priceDetails.append(discountSpan);
       // $('#final-price').val() -= discounted_price;
       var newPrice = parseInt($('#final-price').text().replace(/,/g, "")) - discounted_price;
-      $('#final-price').text(newPrice.toLocaleString())
+      $('#final-price').text(newPrice.toLocaleString('en-US'))
 
 
     }


### PR DESCRIPTION
## Summary
- add a reusable script that converts Arabic-Indic digits to Latin ones across dynamic and static content
- load the digit normalizer on every template that renders a full HTML document so prices stay in Latin numerals sitewide

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e659d25814832087d76a7cc57a4f1d