### PR TITLE
Ensure promotional banner text stays English

### DIFF
--- a/core/templates/website/index.html
+++ b/core/templates/website/index.html
@@ -266,7 +266,7 @@
   <!-- End Row -->
 
   <div class="text-center">
-    <p class="small">{% trans "Limited-time special offers on featured products" %}</p>
+    <p class="small">Limited-time special offers on featured products</p>
   </div>
 </div>
 <!-- End Card Grid -->
@@ -284,8 +284,8 @@
         "
       >
         <div class="card-body">
-          <span class="card-subtitle text-danger">{% trans "Limited time only" %}</span>
-          <h2 class="card-title display-4">{% trans "70% off" %}</h2>
+          <span class="card-subtitle text-danger">Limited time only</span>
+          <h2 class="card-title display-4">70% off</h2>
 
           <div class="w-md-65">
             <!-- Countdown -->
@@ -295,7 +295,7 @@
                   <span class="js-cd-days h2"></span>
                 </div>
 
-                <h5 class="card-title">{% trans "Days" %}</h5>
+                <h5 class="card-title">Days</h5>
               </div>
               <!-- End Col -->
 
@@ -304,7 +304,7 @@
                   <span class="js-cd-hours h2"></span>
                 </div>
 
-                <h5 class="card-title">{% trans "Hours" %}</h5>
+                <h5 class="card-title">Hours</h5>
               </div>
               <!-- End Col -->
 
@@ -313,7 +313,7 @@
                   <span class="js-cd-minutes h2"></span>
                 </div>
 
-                <h5 class="card-title">{% trans "Minutes" %}</h5>
+                <h5 class="card-title">Minutes</h5>
               </div>
               <!-- End Col -->
 
@@ -322,7 +322,7 @@
                   <span class="js-cd-seconds h2"></span>
                 </div>
 
-                <h5 class="card-title">{% trans "Seconds" %}</h5>
+                <h5 class="card-title">Seconds</h5>
               </div>
               <!-- End Col -->
             </div>
@@ -332,7 +332,7 @@
           <a
             class="btn btn-light btn-sm btn-transition rounded-pill px-6"
             href="#"
-            >{% trans "Shop now" %}</a
+            >Shop now</a
           >
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove translation tags from the promotional countdown banner so the copy always renders in English

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6f9d18aac8320ba38456511796321