### PR TITLE
Switch storefront currency labels to XCFA

### DIFF
--- a/core/templates/cart/cart.html
+++ b/core/templates/cart/cart.html
@@ -94,7 +94,7 @@
                     <span class="text-body ms-1"><del>{{prod.prod_obj.price|intcomma}}</del></span>
                     {% endif %}
                     <span class="h5 d-block mb-1">{{prod.prod_obj.offer|intcomma}}</span>
-                    <p>{% trans "Toman" %}</p>
+                    <p>{% trans "XCFA" %}</p>
                     </div>
                     <!-- End Col -->
                   </div>
@@ -137,7 +137,7 @@
                   
                   <dl class="row">
                     <dt class="col-sm-6">{% trans "Subtotal" %}</dt>
-                    <dd class="col-sm-12 text-sm-end mb-0">{{total_price|intcomma}} {% trans "Toman" %}</dd>
+                    <dd class="col-sm-12 text-sm-end mb-0">{{total_price|intcomma}} {% trans "XCFA" %}</dd>
                   </dl>
                   <!-- End Row -->
                 </div>

--- a/core/templates/dashboard/admin/orders/single.html
+++ b/core/templates/dashboard/admin/orders/single.html
@@ -75,13 +75,13 @@
           <dt class="col-md-3">{% trans "Postal code:" %}</dt>
           <dl class="col-md-3">{{order.address.zip_code}}</dl>
           <dt class="col-md-3">{% trans "Original price:" %}</dt>
-          <dl class="col-md-3">{{order.get_totalprice|intcomma}} {% trans "Toman" %}</dl>
+          <dl class="col-md-3">{{order.get_totalprice|intcomma}} {% trans "XCFA" %}</dl>
         </div>
         <div class="row mb-3">
           <dt class="col-md-3">{% trans "Address:" %}</dt>
           <dl class="col-md-3">{{order.get_fulladdress}}</dl>
           <dt class="col-md-3">{% trans "Discounted price:" %}</dt>
-          <dl class="col-md-3">{{order.final_price|intcomma}} {% trans "Toman" %}</dl>
+          <dl class="col-md-3">{{order.final_price|intcomma}} {% trans "XCFA" %}</dl>
         </div>
         <div class=" d-flex pt-5 justify-content-end">
           <a class="btn btn-secondary ms-3" href="{% url 'dashboard:admin:orders-list' %}">{% trans "Back" %}</a>

--- a/core/templates/dashboard/customer/orders/order-detail.html
+++ b/core/templates/dashboard/customer/orders/order-detail.html
@@ -77,13 +77,13 @@
           <dt class="col-md-3">{% trans "Postal code:" %}</dt>
           <dl class="col-md-3">{{order.address.zip_code}}</dl>
           <dt class="col-md-3">{% trans "Original price:" %}</dt>
-          <dl class="col-md-3">{{order.get_totalprice|intcomma}} {% trans "Toman" %}</dl>
+          <dl class="col-md-3">{{order.get_totalprice|intcomma}} {% trans "XCFA" %}</dl>
         </div>
         <div class="row mb-3">
           <dt class="col-md-3">{% trans "Address:" %}</dt>
           <dl class="col-md-3">{{order.get_fulladdress}}</dl>
           <dt class="col-md-3">{% trans "Discounted price:" %}</dt>
-          <dl class="col-md-3">{{order.final_price|intcomma}} {% trans "Toman" %}</dl>
+          <dl class="col-md-3">{{order.final_price|intcomma}} {% trans "XCFA" %}</dl>
         </div>
         <div class=" d-flex pt-5 justify-content-end">
           <a class="btn btn-secondary ms-3" href="{% url 'dashboard:customer:order-list' %}">{% trans "Back" %}</a>

--- a/core/templates/dashboard/customer/orders/order-invoice.html
+++ b/core/templates/dashboard/customer/orders/order-invoice.html
@@ -102,7 +102,7 @@
                     <th>{{product.product.title}}</th>
                     <td>{{product.quantity}}</td>
 
-                    <td class="table-text-end">{{product.product.offer}} {% trans "Toman" %}</td>
+                    <td class="table-text-end">{{product.product.offer}} {% trans "XCFA" %}</td>
                   </tr>
                   {% endfor %}
                 </tbody>
@@ -116,7 +116,7 @@
 
               <div class="row mb-3">
                 <dt class="col-md-3">{% trans "Final price:" %}</dt>
-                <dl class="col-md-3">{{order.get_totalprice|intcomma}} {% trans "Toman" %}</dl>
+                <dl class="col-md-3">{{order.get_totalprice|intcomma}} {% trans "XCFA" %}</dl>
               </div>
               <!-- End Row -->
 

--- a/core/templates/dashboard/customer/orders/orders.html
+++ b/core/templates/dashboard/customer/orders/orders.html
@@ -38,7 +38,7 @@
                 <div class="row">
                   <div class="col-6 col-md mb-3 mb-md-0">
                     <small class="card-subtitle mb-0">{% trans "Total" %}</small>
-                    <small class="text-dark fw-semibold">{{order.final_price|intcomma}} {% trans "Toman" %}</small>
+                    <small class="text-dark fw-semibold">{{order.final_price|intcomma}} {% trans "XCFA" %}</small>
                   </div>
                   <!-- End Col -->
 

--- a/core/templates/includes/latest_prod.html
+++ b/core/templates/includes/latest_prod.html
@@ -47,9 +47,9 @@
               <a class="text-dark" href="{% url 'shop:detail' slug=latest_product.slug %}">{{latest_product.title}}</a>
             </h4>
             {% if latest_product.discount_percent %}
-            <p class="card-text text-dark">{{latest_product.offer|intcomma}} {% trans "Toman" %} <span class="text-body ms-1"><del>{{latest_product.price|intcomma}} {% trans "Toman" %}</del></span></p>
+            <p class="card-text text-dark">{{latest_product.offer|intcomma}} {% trans "XCFA" %} <span class="text-body ms-1"><del>{{latest_product.price|intcomma}} {% trans "XCFA" %}</del></span></p>
             {% else %}
-            <p class="card-text text-dark">{{latest_product.price|intcomma}} {% trans "Toman" %}</p>
+            <p class="card-text text-dark">{{latest_product.price|intcomma}} {% trans "XCFA" %}</p>
             {% endif %}
           </div>
 

--- a/core/templates/includes/popular_product.html
+++ b/core/templates/includes/popular_product.html
@@ -31,7 +31,7 @@
 
       <div class="card-footer text-center">
         <h3 class="card-title">{{category}}</h3>
-        <p class="card-text text-muted small">{% blocktrans with price=min_price|intcomma %}Starting at {{ price }} Toman{% endblocktrans %}</p>
+        <p class="card-text text-muted small">{% blocktrans with price=min_price|intcomma %}Starting at {{ price }} XCFA{% endblocktrans %}</p>
         <a
           class="btn btn-outline-primary btn-sm btn-transition rounded-pill px-6"
           href="/shop/product/list/grid/?q=&category_id={{products.0.category.first.id}}"

--- a/core/templates/includes/similar_prod.html
+++ b/core/templates/includes/similar_prod.html
@@ -47,9 +47,9 @@
                     <a class="text-dark" href="{% url 'shop:detail' slug=similar_prod.slug %}">{{similar_prod.title}}</a>
                   </h4>
                   {% if similar_prod.discount_percent %}
-                  <p class="card-text text-dark">{{similar_prod.offer|intcomma}} {% trans "Toman" %} <span class="text-body ms-1"><del>{{similar_prod.price|intcomma}} {% trans "Toman" %}</del></span></p>
+                  <p class="card-text text-dark">{{similar_prod.offer|intcomma}} {% trans "XCFA" %} <span class="text-body ms-1"><del>{{similar_prod.price|intcomma}} {% trans "XCFA" %}</del></span></p>
                   {% else %}
-                  <p class="card-text text-dark">{{similar_prod.price|intcomma}} {% trans "Toman" %}</p>
+                  <p class="card-text text-dark">{{similar_prod.price|intcomma}} {% trans "XCFA" %}</p>
                   {% endif %}
                 </div>
 

--- a/core/templates/order/checkout.html
+++ b/core/templates/order/checkout.html
@@ -70,9 +70,9 @@
                       <dl class="row">
                         <dt class="col-sm-6">{% trans "Price calculation" %}</dt>
                         <dd class="col-sm-10 text-sm-end mb-0" id="priceDetails">
-                          <span>{% blocktrans %}Total price: {{ total_price|intcomma }} Toman{% endblocktrans %}</span>
+                          <span>{% blocktrans %}Total price: {{ total_price|intcomma }} XCFA{% endblocktrans %}</span>
                           <br>
-                          <span>{% blocktrans %}9% tax: {{ tax_price|intcomma }} Toman{% endblocktrans %}</span>
+                          <span>{% blocktrans %}9% tax: {{ tax_price|intcomma }} XCFA{% endblocktrans %}</span>
                           <br>
                         </dd>
                       </dl>
@@ -80,7 +80,7 @@
                       <dl class="row">
                         <dt class="col-sm-6">{% trans "Grand total" %}</dt>
                         <dd class="col-sm-10 text-sm-end mb-0">
-                          <span id="final-price">{{final_price|intcomma}}</span> {% trans "Toman" %}
+                          <span id="final-price">{{final_price|intcomma}}</span> {% trans "XCFA" %}
                         </dd>
                       </dl>
                       <!-- End Row -->
@@ -127,7 +127,7 @@
 <script>
   function discountPrice(discounted_price){
       // Create a new <span> element with jQuery
-      var discountSpan = $('<span>').text('{{ _("Discount amount:") }} ' + discounted_price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + ' {{ _("Toman") }}');
+      var discountSpan = $('<span>').text('{{ _("Discount amount:") }} ' + discounted_price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + ' {{ _("XCFA") }}');
 
       // Find the target <dd> element
       var priceDetails = $('#priceDetails');

--- a/core/templates/shop/product_detail.html
+++ b/core/templates/shop/product_detail.html
@@ -80,10 +80,10 @@
         <span class="d-block mb-2">{% trans "Total price:" %}</span>
         <div class="d-flex align-items-center">
           {% if object.discount_pecent %}
-          <h3 class="mb-0">{{object.offer|intcomma}} {% trans "Toman" %}</h3>
-          <span class="ms-2"><del>{{object.price|intcomma}} {% trans "Toman" %}</del></span>
+          <h3 class="mb-0">{{object.offer|intcomma}} {% trans "XCFA" %}</h3>
+          <span class="ms-2"><del>{{object.price|intcomma}} {% trans "XCFA" %}</del></span>
           {% else %}
-          <h3 class="mb-0">{{object.price|intcomma}} {% trans "Toman" %}</h3>
+          <h3 class="mb-0">{{object.price|intcomma}} {% trans "XCFA" %}</h3>
           {% endif %}
         </div>
       </div>

--- a/core/templates/shop/products-grid.html
+++ b/core/templates/shop/products-grid.html
@@ -205,9 +205,9 @@
                     <a class="text-dark" href="{% url 'shop:detail' slug=object.slug %}">{{object.title}}</a>
                   </h4>
                   {% if object.discount_percent %}
-                  <p class="card-text text-dark">{{object.offer|intcomma}} {% trans "Toman" %} <span class="text-body ms-1"><del>{{object.price|intcomma}} {% trans "Toman" %}</del></span></p>
+                  <p class="card-text text-dark">{{object.offer|intcomma}} {% trans "XCFA" %} <span class="text-body ms-1"><del>{{object.price|intcomma}} {% trans "XCFA" %}</del></span></p>
                   {% else %}
-                  <p class="card-text text-dark">{{object.price|intcomma}} {% trans "Toman" %}</p>
+                  <p class="card-text text-dark">{{object.price|intcomma}} {% trans "XCFA" %}</p>
                   {% endif %}
                 </div>
 

--- a/core/templates/shop/products-list.html
+++ b/core/templates/shop/products-list.html
@@ -198,9 +198,9 @@
                         <a class="text-dark" href="/product-overview.html">{{object.title}}</a>
                       </h4>
                       {% if object.discount_percent %}
-                      <p class="card-text text-dark">{{object.offer|intcomma}} {% trans "Toman" %}<span class="text-body ms-1"><del>{{object.price|intcomma}} {% trans "Toman" %}</del></span></p>
+                      <p class="card-text text-dark">{{object.offer|intcomma}} {% trans "XCFA" %}<span class="text-body ms-1"><del>{{object.price|intcomma}} {% trans "XCFA" %}</del></span></p>
                       {% else %}
-                      <p class="card-text text-dark">{{object.price|intcomma}} {% trans "Toman" %}</p>
+                      <p class="card-text text-dark">{{object.price|intcomma}} {% trans "XCFA" %}</p>
                       {% endif %}
                     </div>
 


### PR DESCRIPTION
## Summary
- replace all storefront template references to "Toman" with the new XCFA currency label
- update order summaries, product listings, and checkout messaging to consistently show XCFA
- adjust dynamic discount messaging so coupon feedback also uses XCFA

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e714337fe483208c6028dec12ec49d