### PR TITLE
Remove reCAPTCHA requirement from auth forms

### DIFF
--- a/core/accounts/forms.py
+++ b/core/accounts/forms.py
@@ -2,15 +2,12 @@ from django import forms
 from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
 from django.contrib.auth import password_validation
 from django.core.exceptions import ValidationError
-from django_recaptcha.fields import ReCaptchaField
-from django_recaptcha.widgets import ReCaptchaV3
 from .models import User
 from django.utils.translation import gettext_lazy as _
 
 
 class RegistrationForm(UserCreationForm):
     email = forms.EmailField(required=True)
-    captcha = ReCaptchaField(widget=ReCaptchaV3)
 
     class Meta:
         model = User
@@ -18,7 +15,6 @@ class RegistrationForm(UserCreationForm):
 
 
 class CustomAuthenticationForm(AuthenticationForm):
-    captcha = ReCaptchaField(widget=ReCaptchaV3)
 
     error_messages = {
         "invalid_login": _("Please enter a correct email address and password."),

--- a/core/core/settings.py
+++ b/core/core/settings.py
@@ -38,7 +38,6 @@ INSTALLED_APPS = [
     "django.contrib.sitemaps",
     "django_ckeditor_5",
     "minio_storage",
-    "django_recaptcha",
     "website",
     "accounts",
     "shop",
@@ -194,10 +193,6 @@ else:
             "LOCATION": "unique-snowflake",
         }
     }
-
-
-RECAPTCHA_PUBLIC_KEY = "6LcYyLMqAAAAABSQonaG3l7xeOuMowVNQ8jShdG9"
-RECAPTCHA_PRIVATE_KEY = "6LcYyLMqAAAAADNZwf4Z3rQZkA_EJ5hJO8Rvb402"
 
 
 customColorPalette = [

--- a/core/templates/accounts/login.html
+++ b/core/templates/accounts/login.html
@@ -57,7 +57,6 @@
             <div class="text-center">
                 <p>{% trans "Don't have an account?" %} <a class="link" href="{% url 'sign-up' %}">{% trans "Register here" %}</a></p>
             </div>
-            {{form.captcha}}
         </form>
 
         <!-- End Form -->

--- a/core/templates/accounts/signup.html
+++ b/core/templates/accounts/signup.html
@@ -89,7 +89,6 @@
         <div class="text-center">
           <p>{% trans "Already have an account?" %} <a class="link" href="{% url 'login' %}">{% trans "Sign in here" %}</a></p>
         </div>
-        {{form.captcha}}
       </form>
       <!-- End Form -->
     </div>

--- a/requirements.dep.txt
+++ b/requirements.dep.txt
@@ -10,7 +10,6 @@ psycopg==3.2.1
 psycopg-binary==3.2.1
 django-minio-storage
 python-decouple==3.8
-django-recaptcha
 Pillow==10.4.0
 django-redis
 django-ckeditor-5

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -9,7 +9,6 @@ psycopg==3.2.1
 psycopg-binary==3.2.1
 django-minio-storage
 python-decouple==3.8
-django-recaptcha
 Pillow==10.4.0
 django-debug-toolbar
 django-redis


### PR DESCRIPTION
## Summary
- remove django-recaptcha dependency and configuration
- drop captcha fields from login and signup forms and templates

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'decouple')*

------
https://chatgpt.com/codex/tasks/task_e_68e977482b7083209bac1a6353442121